### PR TITLE
Various docs cleared-up

### DIFF
--- a/turnstile/scribblings/reference.scrbl
+++ b/turnstile/scribblings/reference.scrbl
@@ -238,7 +238,9 @@ A @racket[syntax-parse]-like form that supports
 @defform*[((define-primop typed-op-id τ)
            (define-primop typed-op-id : τ)
            (define-primop typed-op-id op-id τ)
-           (define-primop typed-op-id op-id : τ))]{
+           (define-primop typed-op-id op-id : τ)
+           (define-primop typed-op-id #:as op-id τ)
+           (define-primop typed-op-id #:as op-id : τ))]{
 Defines @racket[typed-op-id] by attaching type @racket[τ] to (untyped) 
 identifier @racket[op-id], e.g.:
 

--- a/turnstile/scribblings/reference.scrbl
+++ b/turnstile/scribblings/reference.scrbl
@@ -493,11 +493,16 @@ equality, but includes alpha-equivalence.
     to validate types.
   Binds a @racket[norm] attribute to the type's expanded representation.}}
  @item{@defthing[type-bind stx-class]{A syntax class recognizing
-     syntax objects with shape @racket[[x:id (~datum :) τ:type]].}}
+     syntax objects with shape @racket[[x:id (~datum :) τ:type]].
+  Binds a @racket[x] attribute to the binding identifier, and a @racket[type] attribute
+  to the type's expanded representation.}}
  @item{@defthing[type-ctx stx-class]{A syntax class recognizing
-      syntax objects with shape @racket[(b:type-bind ...)].}}
+      syntax objects with shape @racket[(b:type-bind ...)].
+  Binds a @racket[x] attribute to the binding identifiers, and a @racket[type] attribute
+  to the expanded representation of the types.}}
  @item{@defthing[type-ann stx-class]{A syntax class recognizing
-       syntax objects with shape @racket[{τ:type}] where the braces are required.}}
+       syntax objects with shape @racket[{τ:type}] where the braces are required.
+  Binds a @racket[norm] attribute to the type's expanded representation.}}
 
  @item{@defproc[(assign-type [e syntax?] [τ syntax?]) syntax?]{
 Phase 1 function that calls @racket[current-type-eval] on @racket[τ] and attaches it to @racket[e] using @tt{key1}.}}
@@ -601,7 +606,7 @@ Phase 1 function that replaces occurrences of @racket[x], as determined by @rack
  @racket[τ] in @racket[e].}
 
 @defproc[(substs [τs (listof type-stx)]
-                 [xs (listof id)]
+                 [xs (listof identifier?)]
                  [e expr-stx]
                  [cmp (-> identifier? identifier? boolean?) bound-identifier=?]) expr-stx]{
 Phase 1 function folding @racket[subst] over the given @racket[τs] and @racket[xs].}

--- a/turnstile/scribblings/reference.scrbl
+++ b/turnstile/scribblings/reference.scrbl
@@ -396,8 +396,8 @@ that you can still use other Turnstile conveniences like pattern expanders.}}
                     (code:line #:extra-info stx)])]{
   Analogous to @racket[define-internal-type-constructor], but for binding types.}}
 @item{
-@defform[(type-out ty-id)]{
-A @racket[provide]-spec that, given @racket[ty-id], provides @racket[ty-id], 
+@defform[(type-out ty-id ...)]{
+A @racket[provide]-spec that, for each given @racket[ty-id], provides @racket[ty-id],
 and provides @racket[for-syntax] a predicate @racket[ty-id?] and a @tech:pat-expander @racket[~ty-id].}}
 
 @item{@defparam[current-type-eval type-eval type-eval]{
@@ -582,7 +582,7 @@ expanded identifiers from the contexts, e.g.
 
 might return
 
-@racket[(list '() (list #'x-) (list #'(#%plain-app x- 1))(list #'Int))].
+@racket[(list #'() #'(x-) #'((#%plain-app x- 1)) #'(Int))].
 
 The context elements have the same shape as in @racket[define-typed-syntax].
 The contexts use @racket[let*] semantics, where each binding is in scope for
@@ -594,7 +594,7 @@ want to specify a @litchar{::} key when using @racket[infer] to compute the
 kinds on types.}
 
 @defproc[(subst [τ type-stx]
-                [x id]
+                [x identifier?]
                 [e expr-stx]
                 [cmp (-> identifier? identifier? boolean?) bound-identifier=?]) expr-stx]{
 Phase 1 function that replaces occurrences of @racket[x], as determined by @racket[cmp], with
@@ -630,7 +630,7 @@ The possible variances are:
 
 These are all phase 1 functions.
 
-@defproc[(stx-length [stx syntax?]) Nat]{Analogous to @racket[length].}
+@defproc[(stx-length [stx syntax?]) exact-nonnegative-integer?]{Analogous to @racket[length].}
 @defproc[(stx-length=? [stx1 syntax?] [stx2 syntax?]) boolean?]{
  Returns true if two syntax objects are of equal length.}
 @defproc[(stx-andmap [p? (-> syntax? boolean?)] [stx syntax?]) (listof syntax?)]{


### PR DESCRIPTION
A few things cleared up in the docs such as
 - Existence of keywords
 - Names of bound attribute in syntax classes
 - Proper functionality (syntax-list outputted rather than a regular list as indiciated)
 - Correct contract names