### PR TITLE
attach orig-binding property (used for occurrence typing)

### DIFF
--- a/macrotypes/typecheck.rkt
+++ b/macrotypes/typecheck.rkt
@@ -948,7 +948,8 @@
                 (let*-syntax ([X (make-variable-like-transformer
                                  (mk-tyvar (attach #'X ':: (#,kev #'#%type))))] ...
                               [x (make-variable-like-transformer
-                                  (attachs #'x '(sep ...) #'(τ ...)
+                                  (attachs (attach #'x 'orig-binding #'x)
+                                           '(sep ...) #'(τ ...)
                                            #:ev #,tev))] ...)
                   (#%expression e) ... void)))))
        (list #'tvs+ #'xs+ 


### PR DESCRIPTION
This pull request changes the `infer` function so that when it's introducing variables into the environment, it attaches an extra property so that other rules can find the original variable with the original scopes. This is used for occurrence typing.

Is this the right way to do this? What if one of the attached `sep` properties happens to be the name `orig-binding`?