### PR TITLE
define-typed-variable-syntax

### DIFF
--- a/macrotypes/typecheck.rkt
+++ b/macrotypes/typecheck.rkt
@@ -788,6 +788,18 @@
   (define (var-assign x seps τs)
     (attachs x seps τs #:ev (current-type-eval)))
 
+  ;; macro-var-assign : Id -> (Id (Listof Sym) (StxListof TypeStx) -> Stx)
+  ;; generate a function for current-var-assign that expands
+  ;; to an invocation of the macro by the given identifier
+  ;; e.g.
+  ;;   > (current-var-assign (macro-var-assign #'foo))
+  ;;   > ((current-var-assign) #'x '(:) #'(τ))
+  ;;   #'(foo x : τ)
+  (define ((macro-var-assign mac-id) x seps τs)
+    (with-syntax ([sep+τs (append* (stx-map list seps τs))])
+      (quasisyntax/loc x
+        (#,mac-id #,x . sep+τs))))
+
   ;; current-var-assign :
   ;; (Parameterof [Id (Listof Sym) (StxListof TypeStx) -> Stx])
   (define current-var-assign

--- a/turnstile/examples/linear-var-assign.rkt
+++ b/turnstile/examples/linear-var-assign.rkt
@@ -80,7 +80,7 @@
               '#,(type->str #'τ))]])
 
 
-(define-typed-syntax LIN
+(define-typed-variable-syntax #%lin
   #:datum-literals [:]
   [(_ x- : σ) ≫
    #:when (unrestricted-type? #'σ)
@@ -90,14 +90,6 @@
    #:do [(use-lin-var #'x-)]
    --------
    [⊢ x- ⇒ σ]])
-
-(begin-for-syntax
-  (define (stx-append-map f . lsts)
-    (append* (apply stx-map f lsts)))
-  
-  (current-var-assign
-   (lambda (x seps types)
-     #`(LIN #,x #,@(stx-append-map list seps types)))))
 
 
 (define-typed-syntax #%datum

--- a/turnstile/turnstile.rkt
+++ b/turnstile/turnstile.rkt
@@ -2,7 +2,9 @@
 
 (provide (except-out (all-from-out macrotypes/typecheck) 
                      -define-typed-syntax -define-syntax-category)
-         define-typed-syntax define-syntax-category
+         define-typed-syntax
+         define-typed-variable-syntax
+         define-syntax-category
          (rename-out [define-typed-syntax define-typerule]
                      [define-typed-syntax define-syntax/typecheck])
          (for-syntax syntax-parse/typecheck
@@ -441,6 +443,24 @@
                         [current-ev (current-type-eval)]
                         [current-tag (type-key1)])
            (syntax-parse/typecheck stx kw-stuff ... rule ...)))]))
+
+(define-syntax define-typed-variable-syntax
+  (syntax-parser
+    [(_ (rulename:id . pats) . rst)
+     #'(define-typed-variable-syntax rulename [(_ . pats) . rst])]
+
+    [(_ rulename:id
+        stuff+rules ...)
+     #'(begin
+         (begin-for-syntax
+           [current-var-assign
+            (λ (var seps props)
+              (with-syntax ([X var]
+                            [sep+props (append* (stx-map list seps props))])
+                #'(rulename X . sep+props)))])
+
+         (define-typed-syntax rulename
+           stuff+rules ...))]))
 
 (define-syntax define-syntax-category
   (syntax-parser

--- a/turnstile/turnstile.rkt
+++ b/turnstile/turnstile.rkt
@@ -449,16 +449,10 @@
     [(_ (rulename:id . pats) . rst)
      #'(define-typed-variable-syntax rulename [(_ . pats) . rst])]
 
-    [(_ rulename:id
-        stuff+rules ...)
+    [(_ rulename:id stuff+rules ...)
      #'(begin
          (begin-for-syntax
-           [current-var-assign
-            (λ (var seps props)
-              (with-syntax ([X var]
-                            [sep+props (append* (stx-map list seps props))])
-                #'(rulename X . sep+props)))])
-
+           (current-var-assign (macro-var-assign #'rulename)))
          (define-typed-syntax rulename
            stuff+rules ...))]))
 


### PR DESCRIPTION
Defines a function `macro-var-assign` which returns a fuction for `current-var-assign` that invokes a macro.

```racket
> (current-var-assign (macro-var-assign #'foo))
> ((current-var-assign) #'x '(:) #'(τ))
#'(foo x : τ)
```

Defines a macro `define-typed-variable-syntax` which provides a nice interface for users defining type rules for variables. The macro just creates a macro with `define-typed-syntax` and then immediately binds it as `current-var-assign` using the above function.

```racket
(define-typed-variable-syntax (#%lin-var x : σ) ≫
  #:do [(unless (unrestricted-type? #'σ)
          (use-lin-var #'x))]
  --------
  [⊢ x ⇒ σ])
```