### PR TITLE
Added keyword in premises to allow parameterized call to infer

### DIFF
--- a/turnstile/turnstile.rkt
+++ b/turnstile/turnstile.rkt
@@ -227,9 +227,9 @@
                       (attribute opts.wrap)))])
   (define-splicing-syntax-class tc-post-options
     #:attributes (wrap)
-    [pattern (~seq #:with-param x:id v:expr)
+    [pattern (~seq #:mode x:id v:expr)
              #:attr wrap (λ (stx) #`(parameterize ([x v]) #,stx))]
-    [pattern (~seq #:with-params ([x:id v:expr] ...))
+    [pattern (~seq #:modes ([x:id v:expr] ...))
              #:attr wrap (λ (stx) #`(parameterize ([x v] ...) #,stx))]
     )
   (define-splicing-syntax-class tc-clause

--- a/turnstile/turnstile.rkt
+++ b/turnstile/turnstile.rkt
@@ -197,13 +197,14 @@
              #`(~post
                 #,(with-depth #'tc.e-pat #'[ooo ...]))])
   (define-syntax-class tc*
-    #:attributes (depth es-stx es-stx-orig es-pat)
+    #:attributes (depth es-stx es-stx-orig es-pat wrap-computation)
     [pattern tc:tc-elem
              #:with depth 0
              #:with es-stx #'tc.e-stx
              #:with es-stx-orig #'tc.e-stx-orig
-             #:with es-pat #'tc.e-pat]
-    [pattern (tc:tc ...)
+             #:with es-pat #'tc.e-pat
+             #:attr wrap-computation (λ (stx) stx)]
+    [pattern (tc:tc ... opts:tc-post-options ...)
              #:do [(define ds (stx-map syntax-e #'[tc.depth ...]))
                    (define max-d (apply max 0 ds))]
              #:with depth (add1 max-d)
@@ -218,7 +219,19 @@
                 (add-lists tc-es-pat (- max-d d))))
              #:with es-stx #'[es-stx* ...]
              #:with es-stx-orig #'[es-stx-orig* ...]
-             #:with es-pat #'[es-pat* ...]])
+             #:with es-pat #'[es-pat* ...]
+             #:attr wrap-computation
+             (λ (stx)
+               (foldr (λ (fun stx) (fun stx))
+                      stx
+                      (attribute opts.wrap)))])
+  (define-splicing-syntax-class tc-post-options
+    #:attributes (wrap)
+    [pattern (~seq #:with-param x:id v:expr)
+             #:attr wrap (λ (stx) #`(parameterize ([x v]) #,stx))]
+    [pattern (~seq #:with-params ([x:id v:expr] ...))
+             #:attr wrap (λ (stx) #`(parameterize ([x v] ...) #,stx))]
+    )
   (define-splicing-syntax-class tc-clause
     #:attributes (pat)
     #:datum-literals (⊢)
@@ -238,13 +251,12 @@
              (with-depth
               #`[(tvctx.ctx ...) (ctx.ctx ...) tc.es-stx tc.es-stx-orig]
               #'[ooo ...])
-             #:with pat
-             #`(~post
-                (~post
-                 (~parse
-                  tcs-pat
-                  (infers/depths 'clause-depth 'tc.depth #`tvctxs/ctxs/ess/origs
-                                 #:tag (current-tag)))))]
+             #:with inf #'(infers/depths 'clause-depth
+                                         'tc.depth
+                                         #`tvctxs/ctxs/ess/origs
+                                         #:tag (current-tag))
+             #:with inf+ ((attribute tc.wrap-computation) #'inf)
+             #:with pat #`(~post (~post (~parse tcs-pat inf+)))]
     )
   (define-splicing-syntax-class clause
     #:attributes (pat)


### PR DESCRIPTION
This change supports these keywords at the end of typechecking premises:

```racket
[⊢ [e ≫ e- ⇒ τ] #:with-param parameter local-value]
[⊢ [e ≫ e- ⇒ τ] #:with-params ([param1 value1]
                                [param2 value2])]
```

When supplied, it wraps the call to `infer/depths` in `(parameterize ([...])  ___)`. This is less bug prone and ugly than the current awkward workarounds:
```racket
  #:do [(define prev-value (parameter))
        (parameter local-value)]
  [⊢ e ≫ e- ⇒ τ]
  #:do [(parameter prev-value)]
                                   ;; or
  #:with (_ _ [e-] [τ])
  (parameterize ([parameter local-value])
    (infer #'[e]))
```

Note:
The following syntax is **not** supported (due to how the syntax class `tc` is constructed and used):
```racket
[⊢ e ≫ e- ⇒ τ #:with-param parameter local-value]
```
Also if you place ellipsis after the clause, it will still only evaluate and bind the parameters **once**, e.g. the following is invalid:
```racket
#:with (x ...) <something>
#:with (τ ...) <something>
[⊢ [e ≫ e- ⇒ τ] #:with-param the-thing #'x] ...
```

I don't have any "real" examples that uses this yet, although I know Stephen does and I will have some soon. For now, see [this gist](https://gist.github.com/iitalics/e714b847a26e52dfc7a993325105eb31).