### PR TITLE
added #:mode and #:modes premise syntax

### DIFF
--- a/turnstile/turnstile.rkt
+++ b/turnstile/turnstile.rkt
@@ -317,6 +317,20 @@
     [pattern (~seq #:fail-unless condition:expr message:expr)
              #:with pat
              #'(~post (~fail #:unless condition message))]
+    [pattern (~seq #:mode param:id value:expr (sub-clause:clause ...))
+             #:with tmp (generate-temporary #'param)
+             #:with pat
+             #'(~and (~do (define tmp [param])
+                          [param value])
+                     sub-clause.pat ...
+                     (~do [param tmp]))]
+    [pattern (~seq #:modes ([param:id value:expr] ...) (sub-clause:clause ...))
+             #:with (tmp ...) (generate-temporary #'[param ...])
+             #:with pat
+             #'(~and (~do (define tmp [param]) ...
+                          [param value] ...)
+                     sub-clause.pat ...
+                     (~do [param tmp] ...))]
     )
   (define-syntax-class last-clause
     #:datum-literals (⊢ ≫ ≻ ⇒ ⇐)


### PR DESCRIPTION
Allows for parameterization over mulitple sub-clauses, e.g.

```racket
  #:mode language 'L
    ([⊢ e1 ≫ e1- ⇒ τ]
     [[x ≫ x- : τ] ⊢ e2 ≫ e2- ⇒ σ])
  --------
  [⊢ ...]
```

No examples included but I use it in a [different branch](https://github.com/iitalics/macrotypes/blob/fabul%2Bmodes/turnstile/examples/linear/fabul.rkt#L158).
