### PR TITLE
Stoplist optimization to avoid re-expansion

### DIFF
--- a/macrotypes/examples/fomega.rkt
+++ b/macrotypes/examples/fomega.rkt
@@ -79,7 +79,7 @@
    #:with [e- τ_e] (infer+erase #'e)
    #:with (~∀ (tv ...) τ_body) #'τ_e
    #:with (~∀★ k ...) (kindof #'τ_e)
-;   #:with ([τ- k_τ] ...) (infers+erase #'(τ ...) #:tag '::)
+;   #:with ([τ- k_τ] ...) (infers+erase #'(τ ...) #:tag ':: #:stop-list? #f)
    #:with (k_τ ...) (stx-map kindof #'(τ.norm ...))
    #:fail-unless (kindchecks? #'(k_τ ...) #'(k ...))
                  (typecheck-fail-msg/multi 
@@ -91,7 +91,7 @@
 ;; - see fomega2.rkt
 (define-typed-syntax tyλ
   [(_ bvs:kind-ctx τ_body)
-   #:with (tvs- τ_body- k_body) (infer/ctx+erase #'bvs #'τ_body #:tag '::)
+   #:with (tvs- τ_body- k_body) (infer/ctx+erase #'bvs #'τ_body #:tag ':: #:stop-list? #f)
    #:fail-unless ((current-kind?) #'k_body)
                  (format "not a valid type: ~a\n" (type->str #'τ_body))
    (assign-kind #'(λ- tvs- τ_body-) #'(⇒ bvs.kind ... k_body))])
@@ -99,8 +99,8 @@
 (define-typed-syntax tyapp
   [(_ τ_fn τ_arg ...)
 ;   #:with [τ_fn- (k_in ... k_out)] (⇑ τ_fn as ⇒)
-   #:with [τ_fn- (~⇒ k_in ... k_out)] (infer+erase #'τ_fn #:tag '::)
-   #:with ([τ_arg- k_arg] ...) (infers+erase #'(τ_arg ...) #:tag '::)
+   #:with [τ_fn- (~⇒ k_in ... k_out)] (infer+erase #'τ_fn #:tag ':: #:stop-list? #f)
+   #:with ([τ_arg- k_arg] ...) (infers+erase #'(τ_arg ...) #:tag ':: #:stop-list? #f)
    #:fail-unless (kindchecks? #'(k_arg ...) #'(k_in ...))
                  (string-append
                   (format 

--- a/macrotypes/examples/fomega2.rkt
+++ b/macrotypes/examples/fomega2.rkt
@@ -108,7 +108,7 @@
 ;; extend λ to also work as a type
 (define-typed-syntax λ
   [(_ bvs:kind-ctx τ)           ; type
-   #:with (Xs- τ- k_res) (infer/ctx+erase #'bvs #'τ #:tag '::)
+   #:with (Xs- τ- k_res) (infer/ctx+erase #'bvs #'τ #:tag ':: #:stop-list? #f)
    (assign-kind #'(λ- Xs- τ-) #'(→ bvs.kind ... k_res))]
   [(_ . rst) #'(sysf:λ . rst)]) ; term
 
@@ -116,10 +116,10 @@
 (define-typed-syntax #%app
   [(_ τ_fn τ_arg ...) ; type
 ;   #:with [τ_fn- (k_in ... k_out)] (⇑ τ_fn as ⇒)
-   #:with [τ_fn- k_fn] (infer+erase #'τ_fn #:tag '::)
+   #:with [τ_fn- k_fn] (infer+erase #'τ_fn #:tag ':: #:stop-list? #f)
    #:when (syntax-e #'k_fn) ; non-false
    #:with (~→ k_in ... k_out ~!) #'k_fn
-   #:with ([τ_arg- k_arg] ...) (infers+erase #'(τ_arg ...) #:tag '::)
+   #:with ([τ_arg- k_arg] ...) (infers+erase #'(τ_arg ...) #:tag ':: #:stop-list? #f)
    #:fail-unless (kindchecks? #'(k_arg ...) #'(k_in ...))
                  (string-append
                   (format 

--- a/macrotypes/examples/mlish+adhoc.rkt
+++ b/macrotypes/examples/mlish+adhoc.rkt
@@ -832,6 +832,51 @@
 
 ;; λ --------------------------------------------------------------------------
 
+; Lifted out of the let-syntax ([a ...]) below to avoid generating this meta-level
+;  code at every lambda.
+(define-for-syntax (local-infer Xs xs TCs tys bodya)
+    (define/syntax-parse (X ...) Xs)
+    (define/syntax-parse (x ...) xs)
+    (define/syntax-parse (TC ...) TCs)
+    (define/syntax-parse (ty ...) tys)
+    (define/syntax-parse body bodya)
+    (syntax-parse (expand/df #'(void TC ...)) ; must expand in ctx of Xs
+                      [(_ _ .
+                        (~and (TC+ ...)
+                              (~TCs ([op-sym ty-op] ...) ...)))
+                       ;; here, * suffix = flattened list
+                       ;; op* ... = op-sym ... with proper ctx, and then flattened
+                       #:with (op* ...)
+                              (stx-appendmap 
+                                (lambda (os tc)
+                                  (stx-map (lambda (o) (format-id tc "~a" o)) os))
+                                #'((op-sym ...) ...) #'(TC ...))
+                       #:with (op-tmp* ...) (generate-temporaries #'(op* ...))
+                       #:with (ty-op* ...) (stx-flatten #'((ty-op ...) ...))
+                       #:with ty-in-tagsss
+                              (stx-map 
+                               (syntax-parser
+                                [(~∀ _ fa-body)
+                                 (get-type-tags
+                                  (syntax-parse #'fa-body
+                                   [(~ext-stlc:→ in ... _) #'(in ...)]
+                                   [(~=> _ ... (~ext-stlc:→ in ... _)) #'(in ...)]))])
+                               #'(ty-op* ...))
+                         #:with (mangled-op ...) (stx-map mangle #'(op* ...) #'ty-in-tagsss)
+                         #:with (y ...) #'(x ...)
+                         #:with (_ _ ty+ ...) (expand/df #'(void ty ...))
+                         #:with res
+                         (expand/df 
+                          #'(lambda (op-tmp* ...)
+                             (let-syntax 
+                              ([mangled-op 
+                                (make-rename-transformer (assign-type #'op-tmp* #'ty-op*))] ...)
+                              (lambda (y ...)
+                               (let-syntax
+                                ([y (make-rename-transformer (assign-type #'y #'ty+))] ...)
+                                body)))))
+                         #'((void TC+ ...) (void ty+ ...) res)]))
+
 ; all λs have type (∀ (X ...) (→ τ_in ... τ_out)), even monomorphic fns
 (define-typed-syntax liftedλ #:export-as λ
   [(_ ([x:id (~datum :) ty] ... #:where TC ...) body)
@@ -859,43 +904,8 @@
                  (let-syntax
                   ;; must have this inner macro bc body of lambda may require
                   ;; ops defined by TC to be bound
-                  ([a (syntax-parser [(_)
-                    (syntax-parse (expand/df #'(void TC ...)) ; must expand in ctx of Xs
-                      [(_ _ .
-                        (~and (TC+ (... ...)) 
-                              (~TCs ([op-sym ty-op] (... ...)) (... ...))))
-                       ;; here, * suffix = flattened list
-                       ;; op* ... = op-sym ... with proper ctx, and then flattened
-                       #:with (op* (... ...))
-                              (stx-appendmap 
-                                (lambda (os tc)
-                                  (stx-map (lambda (o) (format-id tc "~a" o)) os))
-                                #'((op-sym (... ...)) (... ...)) #'(TC ...))
-                       #:with (op-tmp* (... ...)) (generate-temporaries #'(op* (... ...)))
-                       #:with (ty-op* (... ...)) (stx-flatten #'((ty-op (... ...)) (... ...)))
-                       #:with ty-in-tagsss
-                              (stx-map 
-                               (syntax-parser
-                                [(~∀ _ fa-body)
-                                 (get-type-tags
-                                  (syntax-parse #'fa-body
-                                   [(~ext-stlc:→ in (... ...) _) #'(in (... ...))]
-                                   [(~=> _ (... ...) (~ext-stlc:→ in (... ...) _)) #'(in (... ...))]))])
-                               #'(ty-op* (... ...)))
-                         #:with (mangled-op (... ...)) (stx-map mangle #'(op* (... ...)) #'ty-in-tagsss)
-                         #:with (y (... ...)) #'(x ...)
-                         #:with (_ _ ty+ (... ...)) (expand/df #'(void ty ...))
-                         #:with res
-                         (expand/df 
-                          #'(lambda (op-tmp* (... ...))
-                             (let-syntax 
-                              ([mangled-op 
-                                (make-rename-transformer (assign-type #'op-tmp* #'ty-op*))] (... ...))
-                              (lambda (y (... ...))
-                               (let-syntax
-                                ([y (make-rename-transformer (assign-type #'y #'ty+))] (... ...))
-                                body)))))
-                         #'((void TC+ (... ...)) (void ty+ (... ...)) res)])])])
+                  ([a (lambda (_)
+                        (local-infer #'(X ...) #'(x ...) #'(TC ...) #'(ty ...) #'body))])
                       (a)))))
    #:with ty-out (typeof #'body+)
    #:with ty-out-expected (get-expected-type #'body+)

--- a/macrotypes/examples/mlish+adhoc.rkt
+++ b/macrotypes/examples/mlish+adhoc.rkt
@@ -1680,7 +1680,7 @@
               (~=> TCsub ... 
                    (~TC [generic-op-expected ty-concrete-op-expected] ...)))
              _)
-            (infers/tyctx+erase #'([X :: #%type] ...) #'(TC ... (Name ty ...)))
+            (infers/tyctx+erase #'([X :: #%type] ...) #'(TC ... (Name ty ...)) #:stop-list? #f)
      #:when (TCs-exist? #'(TCsub ...) #:ctx stx)
      ;; simulate as if the declared concrete-op* has TC ... predicates
      ;; TODO: fix this manual deconstruction and assembly

--- a/macrotypes/examples/perf.rkt
+++ b/macrotypes/examples/perf.rkt
@@ -1,0 +1,6 @@
+#lang s-exp macrotypes/typecheck
+(extends "stlc+lit.rkt")
+
+(require (for-syntax '#%expobs racket))
+
+(provide begin-for-syntax define-syntax (for-syntax (all-from-out racket) current-expand-observe))

--- a/macrotypes/examples/stlc+occurrence.rkt
+++ b/macrotypes/examples/stlc+occurrence.rkt
@@ -252,8 +252,8 @@
    #:with [x2 e2+ τ2] (infer/ctx+erase #'([x-stx : τ-]) #'e2)
    ;; 6. Desugar, replacing the filtered identifier
    (⊢  (if- (f e0+)
-            ((lambda- x1 e1+) x-stx)
-            ((lambda- x2 e2+) x-stx))
+            ((lambda- x1 e1+) x)
+            ((lambda- x2 e2+) x))
       : (∪ τ1 τ2))]
   ;; TODO lists
   ;; For now, we can't express the type (List* A (U A B)), so our filters are too strong
@@ -265,9 +265,9 @@
    #:with [x1 e1+ τ1] (infer/ctx+erase #'([x-stx : τ0+]) #'e1)
    #:with [x2 e2+ τ2] (infer/ctx+erase #'([x-stx : τ0-]) #'e2)
    ;; Expand to a conditional, using the runtime predicate
-   (⊢ (if- (f x-stx)
-           ((lambda- x1 e1+) x-stx)
-           ((lambda- x2 e2+) x-stx))
+   (⊢ (if- (f x)
+           ((lambda- x1 e1+) x)
+           ((lambda- x2 e2+) x))
       : (∪ τ1 τ2))])
 
 ;; =============================================================================

--- a/macrotypes/examples/stlc+overloading.rkt
+++ b/macrotypes/examples/stlc+overloading.rkt
@@ -72,7 +72,7 @@
 
  (define (syntax->ℜ id)
    ;; Don't care about the type
-   (define stx+τ (infer+erase id))
+   (define stx+τ (infer+erase id #:stop-list? #f))
    ;; Boy, I wish I had a monad
    (define (fail)
      (error 'resolve (format "Identifier '~a' is not overloaded" (syntax->datum id))))
@@ -106,7 +106,7 @@
 
 (define-typed-syntax signature
   [(_ (name:id α:id) τ)
-   #:with ((α+) (~→ τ_α:id τ-cod) _) (infer/tyctx+erase #'([α :: #%type]) #'τ)
+   #:with ((α+) (~→ τ_α:id τ-cod) _) (infer/tyctx+erase #'([α :: #%type]) #'τ #:stop-list? #f)
    (define ℜ (ℜ-init #'name #'τ-cod))
    (⊢ (define-syntax name
         (syntax-parser

--- a/macrotypes/examples/stlc+reco+var.rkt
+++ b/macrotypes/examples/stlc+reco+var.rkt
@@ -127,7 +127,7 @@
    #:with [e- τ_e] (infer+erase #'e)
    #:fail-unless (typecheck? #'τ_e #'τ_match)
                  (typecheck-fail-msg/1 #'τ_match #'τ_e #'e)
-   (⊢ (list- 'l e) : τ.norm)])
+   (⊢ (list- 'l e-) : τ.norm)])
 (define-typed-syntax case
   #:datum-literals (of =>)
   [(_ e [l:id x:id => e_l] ...)

--- a/macrotypes/examples/tests/perf.rkt
+++ b/macrotypes/examples/tests/perf.rkt
@@ -1,0 +1,34 @@
+#lang s-exp "../perf.rkt"
+(require "rackunit-typechecking.rkt")
+
+(begin-for-syntax
+  (define (build-term n acc)
+    (if (> n 0)
+        (build-term (- n 1) #`((λ () #,acc)))
+        acc))
+
+  (define the-example
+    (build-term 4 #'(λ () 1))))
+
+
+(define-syntax (m stx)
+  the-example)
+
+(begin-for-syntax
+  (define evt-ct 0)
+  (current-expand-observe (lambda (x y)
+                            (when (= x 0)
+                              ;(displayln x)
+                              #;(displayln (if (syntax? y)
+                                               (syntax->datum y)
+                                               y))
+
+                              #;(displayln "")
+                              (set! evt-ct (+ 1 evt-ct))))))
+
+(m)
+
+(begin-for-syntax
+  (current-expand-observe (lambda (x y) (displayln y)))
+  (displayln evt-ct)
+  )

--- a/macrotypes/examples/tests/perf.rkt
+++ b/macrotypes/examples/tests/perf.rkt
@@ -18,7 +18,7 @@
   (define evt-ct 0)
   (current-expand-observe (lambda (x y)
                             (when (= x 0)
-                              ;(displayln x)
+                              ;(aisplayln x)
                               #;(displayln (if (syntax? y)
                                                (syntax->datum y)
                                                y))
@@ -29,6 +29,5 @@
 (m)
 
 (begin-for-syntax
-  (current-expand-observe (lambda (x y) (displayln y)))
-  (displayln evt-ct)
-  )
+  (current-expand-observe (lambda (x y) (void)))
+  (displayln evt-ct))

--- a/macrotypes/examples/tests/stlc+reco+var-tests.rkt
+++ b/macrotypes/examples/tests/stlc+reco+var-tests.rkt
@@ -1,6 +1,9 @@
 #lang s-exp "../stlc+reco+var.rkt"
 (require "rackunit-typechecking.rkt")
 
+(check-type (λ ([n : Int]) (var b = (tup [c = n]) as (∨ [b : (× [c : Int])])))
+            : (→ Int (∨ [b : (× [c : Int])])))
+
 ;; define-type-alias
 (define-type-alias Integer Int)
 (define-type-alias ArithBinOp (→ Int Int Int))

--- a/turnstile/examples/dep.rkt
+++ b/turnstile/examples/dep.rkt
@@ -1,5 +1,8 @@
 #lang turnstile/lang
 
+(begin-for-syntax
+  (current-use-stop-list? #f))
+
 ; Π  λ ≻ ⊢ ≫ ⇒ ∧ (bidir ⇒ ⇐)
 
 (provide (rename-out [#%type *]) Π → ∀ λ #%app ann define define-type-alias)

--- a/turnstile/examples/mlish+adhoc.rkt
+++ b/turnstile/examples/mlish+adhoc.rkt
@@ -1171,7 +1171,7 @@
    [⊢ n ≫ n- ⇐ Int]
    [⊢ rad ≫ rad- ⇐ Int]
    --------
-   [⊢ (number->string- n rad) ⇒ String]])
+   [⊢ (number->string- n- rad-) ⇒ String]])
 
 (provide (typed-out [string : (→ Char String)]
                     [sleep : (→ Int Unit)]
@@ -1669,8 +1669,8 @@
 (define-typed-syntax define-instance
   ;; base type, possibly with subclasses  ------------------------------------
   [(_ (Name ty ...) [generic-op concrete-op] ...) ≫
-   [⊢ (Name ty ...) ≫ 
-      (~=> TC ... (~TC [generic-op-expected ty-concrete-op-expected] ...)) ⇒ _]
+   #:with (~=> TC ... (~TC [generic-op-expected ty-concrete-op-expected] ...))
+   (expand/df #'(Name ty ...))
    #:when (TCs-exist? #'(TC ...) #:ctx this-syntax)
    #:fail-unless (set=? (syntax->datum #'(generic-op ...)) 
                         (syntax->datum #'(generic-op-expected ...)))
@@ -1724,7 +1724,7 @@
                 (~=> TCsub ... 
                      (~TC [generic-op-expected ty-concrete-op-expected] ...)))
            _)
-           (infers/tyctx+erase #'(X ...) #'(TC ... (Name ty ...)))
+           (infers/tyctx+erase #'(X ...) #'(TC ... (Name ty ...)) #:stop-list? #f)
    ;; this produces #%app bad stx err, so manually call infer for now
    ;; [([X ≫ X- :: #%type] ...) () ⊢ (TC ... (Name ty ...)) ≫
    ;;                                (TC+ ... 

--- a/turnstile/examples/mlish.rkt
+++ b/turnstile/examples/mlish.rkt
@@ -992,7 +992,8 @@
    [⊢ [n ≫ n- ⇐ : Int]]
    [⊢ [rad ≫ rad- ⇐ : Int]]
    --------
-   [⊢ [_ ≫ (number->string- n rad) ⇒ : String]]])
+   [⊢ [_ ≫ (number->string- n- rad-) ⇒ : String]]])
+
 (provide (typed-out [string : (→ Char String)]
                     [sleep : (→ Int Unit)]
                     [string=? : (→ String String Bool)]

--- a/turnstile/examples/stlc+reco+var.rkt
+++ b/turnstile/examples/stlc+reco+var.rkt
@@ -125,7 +125,7 @@
                    this-syntax)))
    [⊢ e ≫ e- ⇐ τ_e]
    --------
-   [⊢ (list- 'l e)]])
+   [⊢ (list- 'l e-)]])
 
 (define-typed-syntax (case e [l:id x:id (~datum =>) e_l] ...) ≫
   #:fail-unless (not (null? (syntax->list #'(l ...)))) "no clauses"

--- a/turnstile/lang.rkt
+++ b/turnstile/lang.rkt
@@ -5,5 +5,5 @@
           macrotypes/typecheck))
 
 (require "turnstile.rkt"
-         (only-in macrotypes/typecheck #%module-begin))
+         (only-in macrotypes/typecheck #%module-begin current-use-stop-list?))
 

--- a/turnstile/turnstile.rkt
+++ b/turnstile/turnstile.rkt
@@ -514,6 +514,9 @@
             #'(define-syntax (rulename stx)
                 (parameterize ([current-check-relation (new-check-rel)]
                                [current-ev (new-eval)]
-                               [current-tag 'key1])
+                               [current-tag 'key1]
+                               ; Syntax categories like kind want full expansion,
+                               ; as types are expected to be fully expanded
+                               [current-use-stop-list? #f])
                   (syntax-parse/typecheck stx kw-stuff (... ...)
                     rule (... ...))))])))]))


### PR DESCRIPTION
API changes: 

1. `#:stop-list?` argument to all the infer variants. Should be set to #f for non-turnstile uses of infer for kind-like things, to ensure full expansion.
2. `current-use-stop-list?` parameter at phase 1. Used by `define-named-syntax` in `define-syntax-category` to ensure full-expansion for turnstile-defined kind expansions. Can also be used to disable the optimization for languages it is not compatible with, like dependent typed languages, or for languages that haven't been migrated to work correctly with the optimization yet. I suggest we do this for typed rosette for the moment.