### PR TITLE
Complexity improvements for scope management

### DIFF
--- a/macrotypes/examples/fomega.rkt
+++ b/macrotypes/examples/fomega.rkt
@@ -79,7 +79,7 @@
    #:with [e- τ_e] (infer+erase #'e)
    #:with (~∀ (tv ...) τ_body) #'τ_e
    #:with (~∀★ k ...) (kindof #'τ_e)
-;   #:with ([τ- k_τ] ...) (infers+erase #'(τ ...) #:tag '::)
+;   #:with ([τ- k_τ] ...) (infers+erase #'(τ ...) #:tag ':: #:stop-list? #f)
    #:with (k_τ ...) (stx-map kindof #'(τ.norm ...))
    #:fail-unless (kindchecks? #'(k_τ ...) #'(k ...))
                  (typecheck-fail-msg/multi 
@@ -91,7 +91,7 @@
 ;; - see fomega2.rkt
 (define-typed-syntax tyλ
   [(_ bvs:kind-ctx τ_body)
-   #:with (tvs- τ_body- k_body) (infer/ctx+erase #'bvs #'τ_body #:tag '::)
+   #:with (tvs- τ_body- k_body) (infer/ctx+erase #'bvs #'τ_body #:tag ':: #:stop-list? #f)
    #:fail-unless ((current-kind?) #'k_body)
                  (format "not a valid type: ~a\n" (type->str #'τ_body))
    (assign-kind #'(λ- tvs- τ_body-) #'(⇒ bvs.kind ... k_body))])
@@ -99,8 +99,8 @@
 (define-typed-syntax tyapp
   [(_ τ_fn τ_arg ...)
 ;   #:with [τ_fn- (k_in ... k_out)] (⇑ τ_fn as ⇒)
-   #:with [τ_fn- (~⇒ k_in ... k_out)] (infer+erase #'τ_fn #:tag '::)
-   #:with ([τ_arg- k_arg] ...) (infers+erase #'(τ_arg ...) #:tag '::)
+   #:with [τ_fn- (~⇒ k_in ... k_out)] (infer+erase #'τ_fn #:tag ':: #:stop-list? #f)
+   #:with ([τ_arg- k_arg] ...) (infers+erase #'(τ_arg ...) #:tag ':: #:stop-list? #f)
    #:fail-unless (kindchecks? #'(k_arg ...) #'(k_in ...))
                  (string-append
                   (format 

--- a/macrotypes/examples/fomega.rkt
+++ b/macrotypes/examples/fomega.rkt
@@ -60,14 +60,14 @@
   (define (type-eval τ) (normalize (old-eval τ)))
   (current-type-eval type-eval)
   
-  (define old-type=? (current-type=?))
+  (define old-typecheck? (current-typecheck-relation))
   ; ty=? == syntax eq and syntax prop eq
-  (define (type=? t1 t2)
+  (define (new-type=? t1 t2)
     (let ([k1 (kindof t1)][k2 (kindof t2)])
       (and (or (and (not k1) (not k2))
-               (and k1 k2 ((current-kind=?) k1 k2)))
-           (old-type=? t1 t2))))
-  (current-typecheck-relation type=?))
+               (and k1 k2 (kind=? k1 k2)))
+           (old-typecheck? t1 t2))))
+  (current-typecheck-relation new-type=?))
 
 (define-typed-syntax Λ
   [(_ bvs:kind-ctx e)

--- a/macrotypes/examples/fomega2.rkt
+++ b/macrotypes/examples/fomega2.rkt
@@ -108,7 +108,7 @@
 ;; extend λ to also work as a type
 (define-typed-syntax λ
   [(_ bvs:kind-ctx τ)           ; type
-   #:with (Xs- τ- k_res) (infer/ctx+erase #'bvs #'τ #:tag '::)
+   #:with (Xs- τ- k_res) (infer/ctx+erase #'bvs #'τ #:tag ':: #:stop-list? #f)
    (assign-kind #'(λ- Xs- τ-) #'(→ bvs.kind ... k_res))]
   [(_ . rst) #'(sysf:λ . rst)]) ; term
 
@@ -116,10 +116,10 @@
 (define-typed-syntax #%app
   [(_ τ_fn τ_arg ...) ; type
 ;   #:with [τ_fn- (k_in ... k_out)] (⇑ τ_fn as ⇒)
-   #:with [τ_fn- k_fn] (infer+erase #'τ_fn #:tag '::)
+   #:with [τ_fn- k_fn] (infer+erase #'τ_fn #:tag ':: #:stop-list? #f)
    #:when (syntax-e #'k_fn) ; non-false
    #:with (~→ k_in ... k_out ~!) #'k_fn
-   #:with ([τ_arg- k_arg] ...) (infers+erase #'(τ_arg ...) #:tag '::)
+   #:with ([τ_arg- k_arg] ...) (infers+erase #'(τ_arg ...) #:tag ':: #:stop-list? #f)
    #:fail-unless (kindchecks? #'(k_arg ...) #'(k_in ...))
                  (string-append
                   (format 

--- a/macrotypes/examples/fomega2.rkt
+++ b/macrotypes/examples/fomega2.rkt
@@ -79,12 +79,11 @@
 
   ;; must be kind= (and not kindcheck?) since old-kind=? recurs on curr-kind=
   (define old-kind=? (current-kind=?))
-  (define (new-kind=? k1 k2)
+  (define (new-kind=? k1 k2 env1 env2)
     (or (and (★? k1) (#%type? k2))
         (and (#%type? k1) (★? k2))
-        (old-kind=? k1 k2)))
-  (current-kind=? new-kind=?)
-  (current-kindcheck-relation new-kind=?))
+        (old-kind=? k1 k2 env1 env2)))
+  (current-kind=? new-kind=?))
 
 (define-typed-syntax Λ
   [(_ bvs:kind-ctx e)

--- a/macrotypes/examples/mlish+adhoc.rkt
+++ b/macrotypes/examples/mlish+adhoc.rkt
@@ -832,6 +832,51 @@
 
 ;; λ --------------------------------------------------------------------------
 
+; Lifted out of the let-syntax ([a ...]) below to avoid generating this meta-level
+;  code at every lambda.
+(define-for-syntax (local-infer Xs xs TCs tys bodya)
+    (define/syntax-parse (X ...) Xs)
+    (define/syntax-parse (x ...) xs)
+    (define/syntax-parse (TC ...) TCs)
+    (define/syntax-parse (ty ...) tys)
+    (define/syntax-parse body bodya)
+    (syntax-parse (expand/df #'(void TC ...)) ; must expand in ctx of Xs
+                      [(_ _ .
+                        (~and (TC+ ...)
+                              (~TCs ([op-sym ty-op] ...) ...)))
+                       ;; here, * suffix = flattened list
+                       ;; op* ... = op-sym ... with proper ctx, and then flattened
+                       #:with (op* ...)
+                              (stx-appendmap 
+                                (lambda (os tc)
+                                  (stx-map (lambda (o) (format-id tc "~a" o)) os))
+                                #'((op-sym ...) ...) #'(TC ...))
+                       #:with (op-tmp* ...) (generate-temporaries #'(op* ...))
+                       #:with (ty-op* ...) (stx-flatten #'((ty-op ...) ...))
+                       #:with ty-in-tagsss
+                              (stx-map 
+                               (syntax-parser
+                                [(~∀ _ fa-body)
+                                 (get-type-tags
+                                  (syntax-parse #'fa-body
+                                   [(~ext-stlc:→ in ... _) #'(in ...)]
+                                   [(~=> _ ... (~ext-stlc:→ in ... _)) #'(in ...)]))])
+                               #'(ty-op* ...))
+                         #:with (mangled-op ...) (stx-map mangle #'(op* ...) #'ty-in-tagsss)
+                         #:with (y ...) #'(x ...)
+                         #:with (_ _ ty+ ...) (expand/df #'(void ty ...))
+                         #:with res
+                         (expand/df 
+                          #'(lambda (op-tmp* ...)
+                             (let-syntax 
+                              ([mangled-op 
+                                (make-rename-transformer (assign-type #'op-tmp* #'ty-op*))] ...)
+                              (lambda (y ...)
+                               (let-syntax
+                                ([y (make-rename-transformer (assign-type #'y #'ty+))] ...)
+                                body)))))
+                         #'((void TC+ ...) (void ty+ ...) res)]))
+
 ; all λs have type (∀ (X ...) (→ τ_in ... τ_out)), even monomorphic fns
 (define-typed-syntax liftedλ #:export-as λ
   [(_ ([x:id (~datum :) ty] ... #:where TC ...) body)
@@ -859,43 +904,8 @@
                  (let-syntax
                   ;; must have this inner macro bc body of lambda may require
                   ;; ops defined by TC to be bound
-                  ([a (syntax-parser [(_)
-                    (syntax-parse (expand/df #'(void TC ...)) ; must expand in ctx of Xs
-                      [(_ _ .
-                        (~and (TC+ (... ...)) 
-                              (~TCs ([op-sym ty-op] (... ...)) (... ...))))
-                       ;; here, * suffix = flattened list
-                       ;; op* ... = op-sym ... with proper ctx, and then flattened
-                       #:with (op* (... ...))
-                              (stx-appendmap 
-                                (lambda (os tc)
-                                  (stx-map (lambda (o) (format-id tc "~a" o)) os))
-                                #'((op-sym (... ...)) (... ...)) #'(TC ...))
-                       #:with (op-tmp* (... ...)) (generate-temporaries #'(op* (... ...)))
-                       #:with (ty-op* (... ...)) (stx-flatten #'((ty-op (... ...)) (... ...)))
-                       #:with ty-in-tagsss
-                              (stx-map 
-                               (syntax-parser
-                                [(~∀ _ fa-body)
-                                 (get-type-tags
-                                  (syntax-parse #'fa-body
-                                   [(~ext-stlc:→ in (... ...) _) #'(in (... ...))]
-                                   [(~=> _ (... ...) (~ext-stlc:→ in (... ...) _)) #'(in (... ...))]))])
-                               #'(ty-op* (... ...)))
-                         #:with (mangled-op (... ...)) (stx-map mangle #'(op* (... ...)) #'ty-in-tagsss)
-                         #:with (y (... ...)) #'(x ...)
-                         #:with (_ _ ty+ (... ...)) (expand/df #'(void ty ...))
-                         #:with res
-                         (expand/df 
-                          #'(lambda (op-tmp* (... ...))
-                             (let-syntax 
-                              ([mangled-op 
-                                (make-rename-transformer (assign-type #'op-tmp* #'ty-op*))] (... ...))
-                              (lambda (y (... ...))
-                               (let-syntax
-                                ([y (make-rename-transformer (assign-type #'y #'ty+))] (... ...))
-                                body)))))
-                         #'((void TC+ (... ...)) (void ty+ (... ...)) res)])])])
+                  ([a (lambda (_)
+                        (local-infer #'(X ...) #'(x ...) #'(TC ...) #'(ty ...) #'body))])
                       (a)))))
    #:with ty-out (typeof #'body+)
    #:with ty-out-expected (get-expected-type #'body+)

--- a/macrotypes/examples/mlish+adhoc.rkt
+++ b/macrotypes/examples/mlish+adhoc.rkt
@@ -1680,7 +1680,7 @@
               (~=> TCsub ... 
                    (~TC [generic-op-expected ty-concrete-op-expected] ...)))
              _)
-            (infers/tyctx+erase #'([X :: #%type] ...) #'(TC ... (Name ty ...)))
+            (infers/tyctx+erase #'([X :: #%type] ...) #'(TC ... (Name ty ...)) #:stop-list? #f)
      #:when (TCs-exist? #'(TCsub ...) #:ctx stx)
      ;; simulate as if the declared concrete-op* has TC ... predicates
      ;; TODO: fix this manual deconstruction and assembly

--- a/macrotypes/examples/perf.rkt
+++ b/macrotypes/examples/perf.rkt
@@ -1,0 +1,6 @@
+#lang s-exp macrotypes/typecheck
+(extends "stlc+lit.rkt")
+
+(require (for-syntax '#%expobs racket))
+
+(provide begin-for-syntax define-syntax (for-syntax (all-from-out racket) current-expand-observe))

--- a/macrotypes/examples/perfsysf.rkt
+++ b/macrotypes/examples/perfsysf.rkt
@@ -1,0 +1,6 @@
+#lang s-exp macrotypes/typecheck
+(extends "sysf.rkt")
+
+(require (for-syntax '#%expobs racket))
+
+(provide begin-for-syntax define-syntax (for-syntax (all-from-out racket) current-expand-observe))

--- a/macrotypes/examples/stlc+occurrence.rkt
+++ b/macrotypes/examples/stlc+occurrence.rkt
@@ -117,7 +117,7 @@
        ;; Remove duplicates from the union, sort members
        (define τ*
          (sort
-          (remove-duplicates (apply append τ**) (current-type=?))
+          (remove-duplicates (apply append τ**) type=?)
           symbol<?
           #:key τ->symbol))
        ;; Check for empty & singleton lists

--- a/macrotypes/examples/stlc+occurrence.rkt
+++ b/macrotypes/examples/stlc+occurrence.rkt
@@ -252,8 +252,8 @@
    #:with [x2 e2+ τ2] (infer/ctx+erase #'([x-stx : τ-]) #'e2)
    ;; 6. Desugar, replacing the filtered identifier
    (⊢  (if- (f e0+)
-            ((lambda- x1 e1+) x-stx)
-            ((lambda- x2 e2+) x-stx))
+            ((lambda- x1 e1+) x)
+            ((lambda- x2 e2+) x))
       : (∪ τ1 τ2))]
   ;; TODO lists
   ;; For now, we can't express the type (List* A (U A B)), so our filters are too strong
@@ -265,9 +265,9 @@
    #:with [x1 e1+ τ1] (infer/ctx+erase #'([x-stx : τ0+]) #'e1)
    #:with [x2 e2+ τ2] (infer/ctx+erase #'([x-stx : τ0-]) #'e2)
    ;; Expand to a conditional, using the runtime predicate
-   (⊢ (if- (f x-stx)
-           ((lambda- x1 e1+) x-stx)
-           ((lambda- x2 e2+) x-stx))
+   (⊢ (if- (f x)
+           ((lambda- x1 e1+) x)
+           ((lambda- x2 e2+) x))
       : (∪ τ1 τ2))])
 
 ;; =============================================================================

--- a/macrotypes/examples/stlc+overloading.rkt
+++ b/macrotypes/examples/stlc+overloading.rkt
@@ -72,7 +72,7 @@
 
  (define (syntax->ℜ id)
    ;; Don't care about the type
-   (define stx+τ (infer+erase id))
+   (define stx+τ (infer+erase id #:stop-list? #f))
    ;; Boy, I wish I had a monad
    (define (fail)
      (error 'resolve (format "Identifier '~a' is not overloaded" (syntax->datum id))))
@@ -106,7 +106,7 @@
 
 (define-typed-syntax signature
   [(_ (name:id α:id) τ)
-   #:with ((α+) (~→ τ_α:id τ-cod) _) (infer/tyctx+erase #'([α :: #%type]) #'τ)
+   #:with ((α+) (~→ τ_α:id τ-cod) _) (infer/tyctx+erase #'([α :: #%type]) #'τ #:stop-list? #f)
    (define ℜ (ℜ-init #'name #'τ-cod))
    (⊢ (define-syntax name
         (syntax-parser

--- a/macrotypes/examples/stlc+overloading.rkt
+++ b/macrotypes/examples/stlc+overloading.rkt
@@ -58,7 +58,7 @@
    ;; First try exact matches, then fall back to subtyping (unless 'exact?' is set).
    ;; When subtyping, the __order instances were declared__ resolves ties.
    (define result
-     (or (ℜ-find ℜ τ #:=? (current-type=?))
+     (or (ℜ-find ℜ τ #:=? type=?)
          (and (not exact?)
               (ℜ-find ℜ τ #:=? (current-typecheck-relation)))))
    (and (pair? result)
@@ -142,12 +142,12 @@
       [((~→ τ_dom1 τ_cod1)
         (~→ _      τ_cod2))
        ;; Really, need to unify this type with the template
-       ;; (unless ((current-type=?) τ_dom1 τ_dom2)
+       ;; (unless (type=? τ_dom1 τ_dom2)
        ;;   (instance-error #'name #'τ (format "Domain '~a' must unify with template domain '~a'."
        ;;                                      (syntax->datum #'τ_dom1) (syntax->datum #'τ_dom2))))
-       (unless ((current-type=?) ((current-type-eval) #'τ) #'τ_dom1)
+       (unless (type=? ((current-type-eval) #'τ) #'τ_dom1)
          (instance-error #'name #'τ (format "Domain '~a' must be the instance type, for now (2015-10-20)." (syntax->datum #'τ_dom1))))
-       (unless ((current-type=?) #'τ_cod1 #'τ_cod2)
+       (unless (type=? #'τ_cod1 #'τ_cod2)
          (instance-error #'name #'τ (format "Codomain '~a' must match template codomain '~a'"
                                             (syntax->datum #'τ_cod1) (syntax->datum #'τ_cod2))))
        (void)]

--- a/macrotypes/examples/stlc+reco+var.rkt
+++ b/macrotypes/examples/stlc+reco+var.rkt
@@ -127,7 +127,7 @@
    #:with [e- τ_e] (infer+erase #'e)
    #:fail-unless (typecheck? #'τ_e #'τ_match)
                  (typecheck-fail-msg/1 #'τ_match #'τ_e #'e)
-   (⊢ (list- 'l e) : τ.norm)])
+   (⊢ (list- 'l e-) : τ.norm)])
 (define-typed-syntax case
   #:datum-literals (of =>)
   [(_ e [l:id x:id => e_l] ...)

--- a/macrotypes/examples/stlc+sub.rkt
+++ b/macrotypes/examples/stlc+sub.rkt
@@ -40,7 +40,7 @@
     (define τ2 ((current-type-eval) t2))
 ;    (printf "t1 = ~a\n" (syntax->datum τ1))
 ;    (printf "t2 = ~a\n" (syntax->datum τ2))
-    (or ((current-type=?) τ1 τ2)
+    (or (type=? τ1 τ2)
         (Top? τ2)))
   (define current-sub? (make-parameter sub?))
   (current-typecheck-relation sub?)

--- a/macrotypes/examples/tests/perf.rkt
+++ b/macrotypes/examples/tests/perf.rkt
@@ -1,0 +1,34 @@
+#lang s-exp "../perf.rkt"
+(require "rackunit-typechecking.rkt")
+
+(begin-for-syntax
+  (define (build-term n acc)
+    (if (> n 0)
+        (build-term (- n 1) #`((λ () #,acc)))
+        acc))
+
+  (define the-example
+    (build-term 4 #'(λ () 1))))
+
+
+(define-syntax (m stx)
+  the-example)
+
+(begin-for-syntax
+  (define evt-ct 0)
+  (current-expand-observe (lambda (x y)
+                            (when (= x 0)
+                              ;(displayln x)
+                              #;(displayln (if (syntax? y)
+                                               (syntax->datum y)
+                                               y))
+
+                              #;(displayln "")
+                              (set! evt-ct (+ 1 evt-ct))))))
+
+(m)
+
+(begin-for-syntax
+  (current-expand-observe (lambda (x y) (displayln y)))
+  (displayln evt-ct)
+  )

--- a/macrotypes/examples/tests/perf.rkt
+++ b/macrotypes/examples/tests/perf.rkt
@@ -18,7 +18,7 @@
   (define evt-ct 0)
   (current-expand-observe (lambda (x y)
                             (when (= x 0)
-                              ;(displayln x)
+                              ;(aisplayln x)
                               #;(displayln (if (syntax? y)
                                                (syntax->datum y)
                                                y))
@@ -29,6 +29,5 @@
 (m)
 
 (begin-for-syntax
-  (current-expand-observe (lambda (x y) (displayln y)))
-  (displayln evt-ct)
-  )
+  (current-expand-observe (lambda (x y) (void)))
+  (displayln evt-ct))

--- a/macrotypes/examples/tests/perfsysf.rkt
+++ b/macrotypes/examples/tests/perfsysf.rkt
@@ -1,0 +1,34 @@
+#lang s-exp "../perfsysf.rkt"
+(require "rackunit-typechecking.rkt")
+
+(begin-for-syntax
+  (define (build-term n acc)
+    (if (> n 0)
+        (build-term (- n 1) #`((λ () #,acc)))
+        acc))
+
+  (define the-example
+    #`((inst #,(build-term 500 #'(Λ (t) (λ ([x : t]) x))) Int) 5)))
+
+
+(define-syntax (m stx)
+  the-example)
+
+(m)
+;(begin-for-syntax
+  ;(define evt-ct 0)
+  ;(current-expand-observe (lambda (x y)
+                            ;(when (= x 0)
+                              ;;(aisplayln x)
+                              ;#;(displayln (if (syntax? y)
+                                               ;(syntax->datum y)
+                                               ;y))
+
+                              ;#;(displayln "")
+                              ;(set! evt-ct (+ 1 evt-ct))))))
+
+;(m)
+
+;(begin-for-syntax
+  ;(current-expand-observe (lambda (x y) (void)))
+  ;(displayln evt-ct))

--- a/macrotypes/examples/tests/stlc+reco+var-tests.rkt
+++ b/macrotypes/examples/tests/stlc+reco+var-tests.rkt
@@ -1,6 +1,9 @@
 #lang s-exp "../stlc+reco+var.rkt"
 (require "rackunit-typechecking.rkt")
 
+(check-type (λ ([n : Int]) (var b = (tup [c = n]) as (∨ [b : (× [c : Int])])))
+            : (→ Int (∨ [b : (× [c : Int])])))
+
 ;; define-type-alias
 (define-type-alias Integer Int)
 (define-type-alias ArithBinOp (→ Int Int Int))

--- a/turnstile/examples/dep.rkt
+++ b/turnstile/examples/dep.rkt
@@ -10,11 +10,10 @@
 #;(begin-for-syntax
   (define old-ty= (current-type=?))
   (current-type=?
-   (λ (t1 t2)
+   (λ (t1 t2 env1 env2)
      (displayln (stx->datum t1))
      (displayln (stx->datum t2))
-     (old-ty= t1 t2)))
-  (current-typecheck-relation (current-type=?)))
+     (old-ty= t1 t2 env1 env2))))
 
 ;(define-syntax-category : kind)
 (define-internal-type-constructor →)

--- a/turnstile/examples/dep.rkt
+++ b/turnstile/examples/dep.rkt
@@ -1,5 +1,8 @@
 #lang turnstile/lang
 
+(begin-for-syntax
+  (current-use-stop-list? #f))
+
 ; Π  λ ≻ ⊢ ≫ ⇒ ∧ (bidir ⇒ ⇐)
 
 (provide (rename-out [#%type *]) Π → ∀ λ #%app ann define define-type-alias)

--- a/turnstile/examples/fomega-no-reuse.rkt
+++ b/turnstile/examples/fomega-no-reuse.rkt
@@ -18,7 +18,7 @@
 ;; - current-type?: well-formed types have kind ★
 ;; - current-any-type?: valid types have any valid kind
 ;; - current-type-eval: reduce tylams and tyapps
-;; - current-type=?: must compare kind annotations as well
+;; - current-typecheck-relation: must compare kind annotations as well
 (begin-for-syntax
   
   ;; well-formed types have kind ★

--- a/turnstile/examples/fomega.rkt
+++ b/turnstile/examples/fomega.rkt
@@ -59,16 +59,16 @@
   (define (new-type-eval τ) (normalize (old-eval τ)))
   (current-type-eval new-type-eval)
   
-  (define old-type=? (current-type=?))
+  (define old-typecheck? (current-typecheck-relation))
   ;; need to also compare kinds of types
-  (define (new-type=? t1 t2)
+  (define (new-typecheck? t1 t2)
     (let ([k1 (kindof t1)][k2 (kindof t2)])
       ;; need these `not` checks bc type= does a structural stx traversal
       ;; and may compare non-type ids (like #%plain-app)
       (and (or (and (not k1) (not k2))
-               (and k1 k2 ((current-kind=?) k1 k2)))
-           (old-type=? t1 t2))))
-  (current-typecheck-relation new-type=?))
+               (and k1 k2 (kind=? k1 k2)))
+           (old-typecheck? t1 t2))))
+  (current-typecheck-relation new-typecheck?))
 
 (define-typed-syntax (Λ bvs:kind-ctx e) ≫
   [[bvs.x ≫ tv- :: bvs.kind] ... ⊢ e ≫ e- ⇒ τ_e]

--- a/turnstile/examples/fomega2.rkt
+++ b/turnstile/examples/fomega2.rkt
@@ -83,12 +83,11 @@
   
   ;; must be kind= (and not kindcheck?) since old-kind=? recurs on curr-kind=
   (define old-kind=? (current-kind=?))
-  (define (new-kind=? k1 k2)
+  (define (new-kind=? k1 k2 env1 env2)
     (or (and (★? k1) (#%type? k2)) ; enables use of existing type defs
         (and (#%type? k1) (★? k2))
-        (old-kind=? k1 k2)))
+        (old-kind=? k1 k2 env1 env2)))
   (current-kind=? new-kind=?)
-  (current-kindcheck-relation new-kind=?)
 
   (define old-typecheck? (current-typecheck-relation))
   (define (new-typecheck? t1 t2)

--- a/turnstile/examples/mlish+adhoc.rkt
+++ b/turnstile/examples/mlish+adhoc.rkt
@@ -1171,7 +1171,7 @@
    [⊢ n ≫ n- ⇐ Int]
    [⊢ rad ≫ rad- ⇐ Int]
    --------
-   [⊢ (number->string- n rad) ⇒ String]])
+   [⊢ (number->string- n- rad-) ⇒ String]])
 
 (provide (typed-out [string : (→ Char String)]
                     [sleep : (→ Int Unit)]
@@ -1669,8 +1669,8 @@
 (define-typed-syntax define-instance
   ;; base type, possibly with subclasses  ------------------------------------
   [(_ (Name ty ...) [generic-op concrete-op] ...) ≫
-   [⊢ (Name ty ...) ≫ 
-      (~=> TC ... (~TC [generic-op-expected ty-concrete-op-expected] ...)) ⇒ _]
+   #:with (~=> TC ... (~TC [generic-op-expected ty-concrete-op-expected] ...))
+   (expand/df #'(Name ty ...))
    #:when (TCs-exist? #'(TC ...) #:ctx this-syntax)
    #:fail-unless (set=? (syntax->datum #'(generic-op ...)) 
                         (syntax->datum #'(generic-op-expected ...)))
@@ -1724,7 +1724,7 @@
                 (~=> TCsub ... 
                      (~TC [generic-op-expected ty-concrete-op-expected] ...)))
            _)
-           (infers/tyctx+erase #'(X ...) #'(TC ... (Name ty ...)))
+           (infers/tyctx+erase #'(X ...) #'(TC ... (Name ty ...)) #:stop-list? #f)
    ;; this produces #%app bad stx err, so manually call infer for now
    ;; [([X ≫ X- :: #%type] ...) () ⊢ (TC ... (Name ty ...)) ≫
    ;;                                (TC+ ... 

--- a/turnstile/examples/mlish.rkt
+++ b/turnstile/examples/mlish.rkt
@@ -992,7 +992,8 @@
    [⊢ [n ≫ n- ⇐ : Int]]
    [⊢ [rad ≫ rad- ⇐ : Int]]
    --------
-   [⊢ [_ ≫ (number->string- n rad) ⇒ : String]]])
+   [⊢ [_ ≫ (number->string- n- rad-) ⇒ : String]]])
+
 (provide (typed-out [string : (→ Char String)]
                     [sleep : (→ Int Unit)]
                     [string=? : (→ String String Bool)]

--- a/turnstile/examples/rosette/rosette2.rkt
+++ b/turnstile/examples/rosette/rosette2.rkt
@@ -674,7 +674,7 @@
     ;; (printf "t2 = ~a\n" (syntax->datum t2))
     (or 
      (Any? t2)
-     ((current-type=?) t1 t2)
+     (type=? t1 t2)
      (syntax-parse (list t1 t2)
        [((~CListof ty1) (~CListof ty2))
         ((current-sub?) #'ty1 #'ty2)]

--- a/turnstile/examples/stlc+reco+var.rkt
+++ b/turnstile/examples/stlc+reco+var.rkt
@@ -125,7 +125,7 @@
                    this-syntax)))
    [⊢ e ≫ e- ⇐ τ_e]
    --------
-   [⊢ (list- 'l e)]])
+   [⊢ (list- 'l e-)]])
 
 (define-typed-syntax (case e [l:id x:id (~datum =>) e_l] ...) ≫
   #:fail-unless (not (null? (syntax->list #'(l ...)))) "no clauses"

--- a/turnstile/examples/stlc+sub.rkt
+++ b/turnstile/examples/stlc+sub.rkt
@@ -48,7 +48,7 @@
     (define τ2 ((current-type-eval) t2))
 ;    (printf "t1 = ~a\n" (syntax->datum τ1))
 ;    (printf "t2 = ~a\n" (syntax->datum τ2))
-    (or ((current-type=?) τ1 τ2)
+    (or (type=? τ1 τ2)
         (Top? τ2)))
   (define current-sub? (make-parameter sub?))
   (current-typecheck-relation sub?)

--- a/turnstile/examples/stlc+union+case.rkt
+++ b/turnstile/examples/stlc+union+case.rkt
@@ -73,7 +73,7 @@
     ;; (printf "t1 = ~a\n" (syntax->datum t1))
     ;; (printf "t2 = ~a\n" (syntax->datum t2))
     (or 
-     ((current-type=?) t1 t2)
+     (type=? t1 t2)
      (syntax-parse (list t1 t2)
        ; 2 U types, subtype = subset
        [((~U* . tys1) _)

--- a/turnstile/examples/stlc+union.rkt
+++ b/turnstile/examples/stlc+union.rkt
@@ -109,7 +109,7 @@
     ;; (printf "t1 = ~a\n" (syntax->datum t1))
     ;; (printf "t2 = ~a\n" (syntax->datum t2))
     (or 
-     ((current-type=?) t1 t2)
+     (type=? t1 t2)
      (syntax-parse (list t1 t2)
        ; 2 U types, subtype = subset
        [((~U* . tys1) (~U* . tys2))

--- a/turnstile/examples/trivial.rkt
+++ b/turnstile/examples/trivial.rkt
@@ -106,21 +106,20 @@
   ;; current-typecheck-relation
   ;; go under CCs if necessary
   (define old-type=? (current-type=?))
-  (define (new-type=? t1 t2) ; extend to literals
+  (define (new-type=? t1 t2 env1 env2) ; extend to literals
     ;; (printf "t1: ~a\n" (syntax->datum t1))
     ;; (printf "t2: ~a\n" (syntax->datum t2))
     (or (Any? t2)
-        (old-type=? t1 t2)
+        (old-type=? t1 t2 env1 env2)
         (equal? (syntax-e t1) (syntax-e t2))
         ;; unwrap CCs if necessary
         (syntax-parse (list t1 t2)
           [((~CCs _ _ _ t1*) _)
-           ((current-type=?) #'t1* t2)]
+           ((current-type=?) #'t1* t2 env1 env2)]
           [(_ (~CCs _ _ _ t2*))
-           ((current-type=?) t1 #'t2*)]
+           ((current-type=?) t1 #'t2* env1 env2)]
           [_ #f])))
   (current-type=? new-type=?)
-  (current-typecheck-relation new-type=?)
 
   ;; current-type?
   ;; TODO: disabling type validation for now

--- a/turnstile/lang.rkt
+++ b/turnstile/lang.rkt
@@ -5,5 +5,5 @@
           macrotypes/typecheck))
 
 (require "turnstile.rkt"
-         (only-in macrotypes/typecheck #%module-begin))
+         (only-in macrotypes/typecheck #%module-begin current-use-stop-list?))
 

--- a/turnstile/turnstile.rkt
+++ b/turnstile/turnstile.rkt
@@ -514,6 +514,9 @@
             #'(define-syntax (rulename stx)
                 (parameterize ([current-check-relation (new-check-rel)]
                                [current-ev (new-eval)]
-                               [current-tag 'key1])
+                               [current-tag 'key1]
+                               ; Syntax categories like kind want full expansion,
+                               ; as types are expected to be fully expanded
+                               [current-use-stop-list? #f])
                   (syntax-parse/typecheck stx kw-stuff (... ...)
                     rule (... ...))))])))]))


### PR DESCRIPTION
1. Rebuild type syntax with fresh variables after each expansion, to avoid build-up of scopes over many re-expansions. This would matter when a type with internal binding structure is attached (and thus re-expanded) to many terms over the course of typechecking.

2. Use environments rather than substitution in `type=?` for comparing type variables.

Doc updates are included.

This PR also includes everything in https://github.com/stchang/macrotypes/pull/41