### PR TITLE
Have assign-type wrap with `erased`, for stop-list

### DIFF
--- a/macrotypes/examples/ext-stlc.rkt
+++ b/macrotypes/examples/ext-stlc.rkt
@@ -55,10 +55,10 @@
 (define-typed-syntax define
   [(_ x:id e)
    #:with (e- τ) (infer+erase #'e)
-   #:with y (generate-temporary)
+   #:with x- (generate-temporary)
    #'(begin-
-       (define-syntax x (make-rename-transformer (⊢ y : τ)))
-       (define- y e-))])
+       (define-typed-variable-rename x ≫ x- : τ)
+       (define- x- e-))])
 
 (define-typed-syntax #%datum
   [(_ . b:boolean) (⊢ #,(syntax/loc stx (#%datum- . b)) : Bool)]

--- a/macrotypes/examples/stlc+cons.rkt
+++ b/macrotypes/examples/stlc+cons.rkt
@@ -49,8 +49,8 @@
                  (typecheck-fail-msg/1 #'τ_list #'τ_e2 #'e2)
    ;; propagate up inferred types of variables
    #:with env (stx-flatten (filter (λ (x) x) (stx-map get-env #'(e1- e2-))))
-   #:with result-cons (add-env #'(cons- e1- e2-) #'env)
-   (⊢/no-teval result-cons : τ_list)])
+   #:with result-cons #'(cons- e1- e2-)
+   (add-env (⊢/no-teval result-cons : τ_list) #'env)])
 (define-typed-syntax isnil
   [(_ e)
    #:with [e- (~List _)] (infer+erase #'e)

--- a/macrotypes/examples/stlc+effect.rkt
+++ b/macrotypes/examples/stlc+effect.rkt
@@ -26,9 +26,8 @@
      
   (define (get-effects e tag [vs '()])
     (or (syntax-property
-         (local-expand
-          (if (null? vs) e #`(stlc+box:λ #,vs #,e)) 'expression null)
-         tag)
+          (first (infer+erase (if (null? vs) e #`(stlc+box:λ #,vs #,e))))
+          tag)
         null))
   (define (get-new-effects e [vs '()]) (get-effects e 'ν vs))
   (define (get-assign-effects e [vs '()]) (get-effects e ':= vs))
@@ -36,7 +35,7 @@
   
   (define (print-effects e)
     (printf "expr ~a\n" (syntax->datum e))
-    (define e+ (local-expand e 'expression null))
+    (define e+ (first (infer+erase e)))
     (printf "new locs: ~a\n" (syntax-property e+ 'ν))
     (printf "deref locs: ~a\n" (syntax-property e+ '!))
     (printf "assign locs: ~a\n" (syntax-property e+ ':=)))
@@ -91,7 +90,7 @@
           (get-assign-effects #'e-)
           (get-deref-effects #'e-)))
   (define (assign-type/eff e ty news assigns derefs)
-    (assign-type (add-effects e news assigns derefs) ty)))
+    (add-effects (assign-type e ty) news assigns derefs)))
 
 (define-typed-syntax ref
   [(_ e)

--- a/macrotypes/examples/tests/mlish/generic.mlish
+++ b/macrotypes/examples/tests/mlish/generic.mlish
@@ -21,10 +21,10 @@
 (typecheck-fail (== "1" "1")
   #:with-msg "== operation undefined for input types: String, String")
 
+
 (define-instance (Eq String) ; test use of lambda on rhs
   [== (λ ([x : String] [y : String]) 
         (string=? x y))])
-
 (check-type (== "1" "2") : Bool -> (string=? "1" "2"))
 (check-type (== "1" "2") : Bool -> #f)
 (check-type (== "2" "2") : Bool -> (string=? "2" "2"))

--- a/turnstile/examples/ext-stlc.rkt
+++ b/turnstile/examples/ext-stlc.rkt
@@ -53,16 +53,16 @@
 (define-typed-syntax define
   [(_ x:id (~datum :) τ:type e:expr) ≫
    ;[⊢ e ≫ e- ⇐ τ.norm]
-   #:with y (generate-temporary #'x)
+   #:with x- (generate-temporary #'x)
    --------
    [≻ (begin-
-        (define-syntax x (make-rename-transformer (⊢ y : τ.norm)))
-        (define- y (ann e : τ.norm)))]]
+        (define-typed-variable-rename x ≫ x- : τ.norm)
+        (define- x- (ann e : τ.norm)))]]
   [(_ x:id e) ≫
    ;This won't work with mutually recursive definitions
    [⊢ e ≫ e- ⇒ τ]
    #:with y (generate-temporary #'x)
-   #:with y+props (transfer-props #'e- (assign-type #'y #'τ))
+   #:with y+props (transfer-props #'e- (assign-type #'y #'τ #:wrap? #f))
    --------
    [≻ (begin-
         (define-syntax x (make-rename-transformer #'y+props))
@@ -71,8 +71,7 @@
    #:with f- (add-orig (generate-temporary #'f) #'f)
    --------
    [≻ (begin-
-        (define-syntax- f
-          (make-rename-transformer (⊢ f- : (→ ty ... ty_out))))
+        (define-typed-variable-rename f ≫ f- : (→ ty ... ty_out))
         (define- f-
           (stlc+lit:λ ([x : ty] ...)
             (stlc+lit:ann (begin e ...) : ty_out))))]])

--- a/turnstile/examples/infer.rkt
+++ b/turnstile/examples/infer.rkt
@@ -205,16 +205,16 @@
 (define-typed-syntax define
   [(define x:id e:expr) ≫
    [⊢ [e ≫ e- ⇒ : τ_e]]
-   #:with tmp (generate-temporary #'x)
+   #:with x- (generate-temporary #'x)
    --------
    [_ ≻ (begin-
-          (define-syntax- x (make-rename-transformer (⊢ tmp : τ_e)))
-          (define- tmp e-))]])
+          (define-typed-variable-rename x ≫ x- : τ_e)
+          (define- x- e-))]])
 
 (define-typed-syntax define/rec #:datum-literals (:)
   [(define/rec x:id : τ_x:type e:expr) ≫
-   #:with tmp (generate-temporary #'x)
+   #:with x- (generate-temporary #'x)
    --------
    [_ ≻ (begin-
-          (define-syntax- x (make-rename-transformer (⊢ tmp : τ_x.norm)))
-          (define- tmp (ann e : τ_x.norm)))]])
+          (define-typed-variable-rename x ≫ x- : τ_x.norm)
+          (define- x- (ann e : τ_x.norm)))]])

--- a/turnstile/examples/linear/fabul.rkt
+++ b/turnstile/examples/linear/fabul.rkt
@@ -210,11 +210,11 @@
   [(_ x:id : τ:type e:expr) ≫
    #:fail-when (linear-type? #'τ.norm)
                "cannot define linear type globally"
-   #:with y (generate-temporary #'x)
+   #:with x- (generate-temporary #'x)
    --------
    [≻ (begin-
-        (define-syntax x (make-rename-transformer (⊢ y : τ.norm)))
-        (define- y (ann e : τ.norm)))]])
+        (define-typed-variable-rename x ≫ x- : τ.norm)
+        (define- x- (ann e : τ.norm)))]])
 
 
 ; REPL prints expression types

--- a/turnstile/examples/linear/lin.rkt
+++ b/turnstile/examples/linear/lin.rkt
@@ -343,8 +343,8 @@
   [(_ x:id : τ:type e:expr) ≫
    #:fail-when (linear-type? #'τ.norm)
                "cannot define linear type globally"
-   #:with y (generate-temporary #'x)
+   #:with x- (generate-temporary #'x)
    --------
    [≻ (begin-
-        (define-syntax x (make-rename-transformer (⊢ y : τ.norm)))
-        (define- y (ann e : τ.norm)))]])
+        (define-typed-variable-rename x ≫ x- : τ.norm)
+        (define- x- (ann e : τ.norm)))]])

--- a/turnstile/examples/mlish+adhoc.rkt
+++ b/turnstile/examples/mlish+adhoc.rkt
@@ -272,17 +272,17 @@
 (define-typed-syntax define/tc #:export-as define
   [(_ x:id e) ≫
    [⊢ e ≫ e- ⇒ τ]
-   #:with y (generate-temporary)
+   #:with x- (generate-temporary)
    --------
    [≻ (begin-
-        (define-syntax- x (make-rename-transformer (⊢ y : τ)))
-        (define- y e-))]]
+        (define-typed-variable-rename x ≫ x- : τ)
+        (define- x- e-))]]
   ; explicit "forall"
   [(_ Ys (f:id [x:id (~datum :) τ] ... (~or (~datum ->) (~datum →)) τ_out) 
       e_body ... e) ≫
    #:when (brace? #'Ys)
    ;; TODO; remove this code duplication
-   #:with g (add-orig (generate-temporary #'f) #'f)
+   #:with f- (add-orig (generate-temporary #'f) #'f)
    #:with e_ann (syntax/loc #'e (add-expected e τ_out))
    #:with (τ+orig ...) (stx-map (λ (t) (add-orig t t)) #'(τ ... τ_out))
    ;; TODO: check that specified return type is correct
@@ -292,8 +292,8 @@
           ((current-type-eval) #'(∀ Ys (ext-stlc:→ τ+orig ...)))
    --------
    [≻ (begin-
-        (define-syntax- f (make-rename-transformer (⊢ g : ty_fn_expected)))
-        (define- g
+        (define-typed-variable-rename f ≫ f- : ty_fn_expected)
+        (define- f-
           (Λ Ys (ext-stlc:λ ([x : τ] ...) (ext-stlc:begin e_body ... e_ann)))))]]
   ;; alternate type sig syntax, after parameter names
   [(_ (f:id x:id ...) (~datum :) ty ... (~or (~datum ->) (~datum →)) ty_out . b) ≫
@@ -303,7 +303,7 @@
             (~or (~datum ->) (~datum →)) τ_out)
       e_body ... e) ≫
    #:with (~and Ys (Y ...)) (compute-tyvars #'(τ ... τ_out))
-   #:with g (add-orig (generate-temporary #'f) #'f)
+   #:with f- (add-orig (generate-temporary #'f) #'f)
    #:with e_ann (syntax/loc #'e (add-expected e τ_out)) ; must be macro bc t_out may have unbound tvs
    #:with (τ+orig ...) (stx-map (λ (t) (add-orig t t)) #'(τ ... τ_out))
    ;; TODO: check that specified return type is correct
@@ -316,15 +316,15 @@
            (list #'(→ τ+orig ...)))
    --------
    [≻ (begin-
-        (define-syntax- f (make-rename-transformer (⊢ g : ty_fn_expected)))
-        (define- g
+        (define-typed-variable-rename f ≫ f- : ty_fn_expected)
+        (define- f-
           (Λ Ys (ext-stlc:λ ([x : τ] ...) (ext-stlc:begin e_body ... e_ann)))))]]
   [(_ (f:id [x:id (~datum :) τ] ... 
             (~seq #:where TC ...)
             (~or (~datum ->) (~datum →)) τ_out)
       e_body ... e) ≫
    #:with (~and Ys (Y ...)) (compute-tyvars #'(τ ... τ_out))
-   #:with g (add-orig (generate-temporary #'f) #'f)
+   #:with f- (add-orig (generate-temporary #'f) #'f)
    #:with e_ann (syntax/loc #'e (add-expected e τ_out)) ; must be macro bc t_out may have unbound tvs
    #:with (τ+orig ...) (stx-map (λ (t) (add-orig t t)) #'(τ ... τ_out))
    ;; TODO: check that specified return type is correct
@@ -337,9 +337,9 @@
             (list #'(→ τ+orig ...)))
    --------
    [≻ (begin-
-        (define-syntax- f (make-rename-transformer (⊢ g : ty_fn_expected)))
+        (define-typed-variable-rename f ≫ f- : ty_fn_expected)
         #,(quasisyntax/loc this-syntax
-            (define- g
+            (define- f-
               ;(Λ Ys (ext-stlc:λ ([x : τ] ...) (ext-stlc:begin e_body ... e_ann)))))])
               (liftedλ {Y ...} ([x : τ] ... #:where TC ...) 
                        #,(syntax/loc #'e_ann (ext-stlc:begin e_body ... e_ann))))))]])
@@ -817,95 +817,42 @@
                     [odd? : (→ Int Bool)]))
 
 ;; λ --------------------------------------------------------------------------
+(define-typed-syntax BindTC
+  [(_ (TC ...) body) ≫
+   #:with (~and (TC+ ...) (~TCs ([op-sym ty-op] ...) ...))
+          (stx-map expand/df #'(TC ...))
+   #:with (op* ...)
+   (stx-appendmap
+     (lambda (os tc)
+       (stx-map (lambda (o) (format-id tc "~a" o)) os))
+     #'((op-sym ...) ...) #'(TC ...))
+   #:with (ty-op* ...) (stx-flatten #'((ty-op ...) ...))
+   #:with ty-in-tagsss
+   (stx-map
+     (syntax-parser
+       [(~∀ _ fa-body)
+        (get-type-tags
+          (syntax-parse #'fa-body
+                        [(~ext-stlc:→ in ... _) #'(in ...)]
+                        [(~=> _ ... (~ext-stlc:→ in ... _)) #'(in ...)]))])
+     #'(ty-op* ...))
+   #:with (mangled-op ...) (stx-map mangle #'(op* ...) #'ty-in-tagsss)
 
-; Lifted out of the let-syntax ([a ...]) below to avoid generating this meta-level
+   #:with (mangled-ops- body- t-) (infer/ctx+erase #'([mangled-op : ty-op*] ...)
+                                           #'body)
+   --------
+   [⊢ (λ- mangled-ops- body-) ⇒ (=> TC+ ... t-)]])
 
-(define-for-syntax (local-infer Xs xs TCs tys bodya)
-    (define/syntax-parse (X ...) Xs)
-    (define/syntax-parse (x ...) xs)
-    (define/syntax-parse (TC ...) TCs)
-    (define/syntax-parse (ty ...) tys)
-    (define/syntax-parse body bodya)
-
-    (syntax-parse (expand/df #'(void TC ...)) ; must expand in ctx of Xs
-                      [(_ _ .
-                        (~and (TC+ ...) 
-                              (~TCs ([op-sym ty-op] ...) ...)))
-                       ;; here, * suffix = flattened list
-                       ;; op* ... = op-sym ... with proper ctx, and then flattened
-                       #:with (op* ...)
-                              (stx-appendmap 
-                                (lambda (os tc)
-                                  (stx-map (lambda (o) (format-id tc "~a" o)) os))
-                                #'((op-sym ...) ...) #'(TC ...))
-                       #:with (op-tmp* ...) (generate-temporaries #'(op* ...))
-                       #:with (ty-op* ...) (stx-flatten #'((ty-op ...) ...))
-                       #:with ty-in-tagsss
-                              (stx-map 
-                               (syntax-parser
-                                [(~∀ _ fa-body)
-                                 (get-type-tags
-                                  (syntax-parse #'fa-body
-                                   [(~ext-stlc:→ in ... _) #'(in ...)]
-                                   [(~=> _ ... (~ext-stlc:→ in ... _)) #'(in ...)]))])
-                               #'(ty-op* ...))
-                         #:with (mangled-op ...) (stx-map mangle #'(op* ...) #'ty-in-tagsss)
-                         #:with (y ...) #'(x ...)
-                         #:with (_ _ ty+ ...) (expand/df #'(void ty ...))
-                         #:with res
-                         (expand/df 
-                          #'(lambda (op-tmp* ...)
-                             (let-syntax 
-                              ([mangled-op 
-                                (make-rename-transformer (assign-type #'op-tmp* #'ty-op*))] ...)
-                              (lambda (y ...)
-                               (let-syntax
-                                ([y (make-rename-transformer (assign-type #'y #'ty+))] ...)
-                                body)))))
-                         #'((void TC+ ...) (void ty+ ...) res)])
-
-    )
 ; all λs have type (∀ (X ...) (→ τ_in ... τ_out)), even monomorphic fns
 (define-typed-syntax liftedλ #:export-as λ
   [(_ ([x:id (~datum :) ty] ... #:where TC ...) body) ≫
    #:with (X ...) (compute-tyvars #'(ty ...))
    --------
    [≻ (liftedλ {X ...} ([x : ty] ... #:where TC ...) body)]]
-  ;; TODO: I dont think this works for nested lambdas
-  ;; ie, this will will re-infer tyvars X that should be bound by outer lam
-  ;; - tyvars need to be bound in 2nd expand/df
-  ;; - This is fixed in master by Alex
   [(_ (~and Xs (X ...)) ([x:id (~datum :) ty] ... #:where TC ...) body) ≫
    #:when (brace? #'Xs)
-   #:with (_ Xs+
-           (_ () (_ () (_ () (_ () ; 2 let-stx = 4 let-values
-            (_ (_ _ TC+ ...) 
-               (_ _ ty+ ...)
-               (_ op-tmps+
-                (_ () (_ ()
-                 ((~literal #%expression)
-                  (_ xs+
-                   (_ () (_ () body+)))))))))))))
-           (expand/df
-            #'(lambda (X ...) 
-                (let-syntax 
-                 ([X (make-rename-transformer (mk-type #'X))] ...)
-                 (let-syntax
-                  ;; must have this inner macro bc body of lambda may require
-                  ;; ops defined by TC to be bound
-                  ([a (lambda (_)
-                        (local-infer #'(X ...) #'(x ...) #'(TC ...) #'(ty ...) #'body))])
-                      (a)))))
-   #:with ty-out (typeof #'body+)
-   #:with ty-out-expected (get-expected-type #'body+)
-   #:fail-unless (or (not (syntax-e #'ty-out-expected))
-                     (typecheck? #'ty-out #'ty-out-expected))
-                 (type-error #:src #'body
-                  #:msg "Body has type ~a, expected/given: ~a"
-                  #'ty-out #'ty-out-expected)
    --------
-   [⊢ (λ- op-tmps+ (λ- xs+ body+)) 
-      ⇒ (∀ Xs+ (=> TC+ ... (ext-stlc:→ ty+ ... ty-out)))]]
+   [≻ (Λ (X ...) (BindTC (TC ...) (ext-stlc:λ ([x : ty] ...) body)))]]
   [(_ ([x:id (~datum :) ty] ...) body) ≫ ; no TC
    #:with (X ...) (compute-tyvars #'(ty ...))
    #:with (~∀ () (~ext-stlc:→ _ ... body-ty)) (get-expected-type this-syntax)
@@ -1546,11 +1493,11 @@
         (provide- x-ty ...))]])
 (define-typed-syntax (require-typed x:id ... #:from mod) ≫
   #:with (x-ty ...) (stx-map (lambda (y) (format-id y "~a-ty" y)) #'(x ...))
-  #:with (y ...) (generate-temporaries #'(x ...))
+  #:with (x- ...) (generate-temporaries #'(x ...))
   --------
   [≻ (begin-
-       (require- (rename-in (only-in mod x ... x-ty ...) [x y] ...))
-       (define-syntax x (make-rename-transformer (assign-type #'y #'x-ty))) ...)])
+       (require- (rename-in (only-in mod x ... x-ty ...) [x x-] ...))
+       (define-typed-variable-rename x ≫ x- : x-ty) ...)])
 
 (define-base-type Regexp)
 (provide (typed-out [regexp-match : (→ Regexp String (List String))]
@@ -1612,9 +1559,13 @@
                    (syntax->list #'((ty-arg ...) ...))))
        : ty-conc-op-noTC)]
    ;; base type --------------------------------------------------
-   [(((~literal #%plain-app) tag) ...) (expand/df (mangle gen-op #'(tag ...)))]
+   [(((~literal #%plain-app) tag) ...)
+    #:with (op- t-) (infer+erase (mangle gen-op #'(tag ...)))
+    #'op-]
    ;; tyvars --------------------------------------------------
-   [_ (expand/df (mangle gen-op tys))]))
+   [_
+     #:with (op- t-) (infer+erase (mangle gen-op tys))
+     #'op-]))
  (define (get-fn-ty-in-tags ty-fn)
    (syntax-parse ty-fn
      [(~∀ _ (~ext-stlc:→ ty_in ... _))

--- a/turnstile/examples/mlish.rkt
+++ b/turnstile/examples/mlish.rkt
@@ -332,17 +332,17 @@
 (define-typed-syntax define
   [(_ x:id e) ≫
    [⊢ e ≫ e- ⇒ τ]
-   #:with y (generate-temporary)
+   #:with x- (generate-temporary)
    --------
    [≻ (begin-
-        (define-syntax x (make-rename-transformer (⊢ y : τ)))
-        (define- y e-))]]
+        (define-typed-variable-rename x ≫ x- : τ)
+        (define- x- e-))]]
   ; explicit "forall"
   [(_ Ys (f:id [x:id (~datum :) τ] ... (~or (~datum ->) (~datum →)) τ_out) 
      e_body ... e) ≫
    #:when (brace? #'Ys)
    ;; TODO; remove this code duplication
-   #:with g (add-orig (generate-temporary #'f) #'f)
+   #:with f- (add-orig (generate-temporary #'f) #'f)
    #:with e_ann #'(add-expected e τ_out)
    #:with (τ+orig ...) (stx-map (λ (t) (add-orig t t)) #'(τ ... τ_out))
    ;; TODO: check that specified return type is correct
@@ -352,8 +352,8 @@
           ((current-type-eval) #'(?∀ Ys (ext-stlc:→ τ+orig ...)))
    --------
    [≻ (begin-
-        (define-syntax f (make-rename-transformer (⊢ g : ty_fn_expected)))
-        (define- g
+        (define-typed-variable-rename f ≫ f- : ty_fn_expected)
+        (define- f-
           (Λ Ys (ext-stlc:λ ([x : τ] ...) (ext-stlc:begin e_body ... e_ann)))))]]
   ;; alternate type sig syntax, after parameter names
   [(_ (f:id x:id ...) (~datum :) ty ... (~or (~datum ->) (~datum →)) ty_out . b) ≫
@@ -362,7 +362,7 @@
   [(_ (f:id [x:id (~datum :) τ] ... (~or (~datum ->) (~datum →)) τ_out) 
      e_body ... e) ≫
    #:with Ys (compute-tyvars #'(τ ... τ_out))
-   #:with g (add-orig (generate-temporary #'f) #'f)
+   #:with f- (add-orig (generate-temporary #'f) #'f)
    #:with e_ann (syntax/loc #'e (ann e : τ_out)) ; must be macro bc t_out may have unbound tvs
    #:with (τ+orig ...) (stx-map (λ (t) (add-orig t t)) #'(τ ... τ_out))
    ;; TODO: check that specified return type is correct
@@ -375,8 +375,8 @@
            (list #'(→ τ+orig ...)))
    --------
    [≻ (begin-
-        (define-syntax f (make-rename-transformer (⊢ g : ty_fn_expected)))
-        (define- g
+        (define-typed-variable-rename f ≫ f- : ty_fn_expected)
+        (define- f-
           (?Λ Ys (ext-stlc:λ ([x : τ] ...) (ext-stlc:begin e_body ... e_ann)))))]])
 
 ;; define-type -----------------------------------------------
@@ -1391,11 +1391,11 @@
 (define-typed-syntax require-typed
   [(require-typed x:id ... #:from mod) ≫
    #:with (x-ty ...) (stx-map (lambda (y) (format-id y "~a-ty" y)) #'(x ...))
-   #:with (y ...) (generate-temporaries #'(x ...))
+   #:with (x- ...) (generate-temporaries #'(x ...))
    --------
    [_ ≻ (begin-
-          (require- (rename-in (only-in mod x ... x-ty ...) [x y] ...))
-          (define-syntax x (make-rename-transformer (assign-type #'y #'x-ty))) ...)]])
+          (require- (rename-in (only-in mod x ... x-ty ...) [x x-] ...))
+          (define-typed-variable-rename x ≫ x- : x-ty) ...)]])
 
 (define-base-type Regexp)
 (provide (typed-out [regexp-match : (→ Regexp String (List String))]

--- a/turnstile/examples/rosette/bv.rkt
+++ b/turnstile/examples/rosette/bv.rkt
@@ -65,11 +65,8 @@
                 #:implements spec-
                 #:library lib-expr- 
                 #:minbv minbv-))
-          (define-syntax id
-            (make-rename-transformer (⊢ id-internal : ty_spec)))
-          (define-syntax id-stx
-            (make-rename-transformer (⊢ id-stx-internal : CStx)))
-          )]])
+          (define-typed-variable-rename id ≫ id-internal : ty_spec)
+          (define-typed-variable-rename id-stx ≫ id-stx-internal : CStx))]])
 
 (define-typed-syntax bvlib
   [(_ [(~and ids (id ...)) n] ...) ≫

--- a/turnstile/examples/rosette/query/debug.rkt
+++ b/turnstile/examples/rosette/query/debug.rkt
@@ -12,15 +12,14 @@
    #:with y (generate-temporary #'x)
    --------
    [_ ≻ (begin-
-          (define-syntax- x (make-rename-transformer (⊢ y : τ)))
+          (define-typed-variable-rename x ≫ y : τ)
           (ro:define/debug y e-))]]
   [(_ (f [x : ty] ... (~or → ->) ty_out) e ...+) ≫
 ;   [⊢ [e ≫ e- ⇒ : ty_e]]
    #:with f- (generate-temporary #'f)
    --------
    [_ ≻ (begin-
-          (define-syntax- f
-            (make-rename-transformer (⊢ f- : (t/ro:C→ ty ... ty_out))))
+          (define-typed-variable-rename f ≫ f- : (t/ro:C→ ty ... ty_out))
           (ro:define/debug f- 
             (t/ro:λ ([x : ty] ...) 
               (t/ro:ann (t/ro:begin e ...) : ty_out))))]])

--- a/turnstile/examples/rosette/rosette.rkt
+++ b/turnstile/examples/rosette/rosette.rkt
@@ -41,7 +41,7 @@
    #:with (y ...) (generate-temporaries #'(x ...))
    --------
    [_ ≻ (begin-
-          (define-syntax- x (make-rename-transformer (⊢ y : ty.norm))) ...
+          (define-typed-variable-rename x ≫ y : ty.norm)
           (ro:define-symbolic y ... pred-))]])
 
 (define-typed-syntax choose
@@ -169,8 +169,7 @@
    #:with f- (generate-temporary #'f)
    --------
    [_ ≻ (begin-
-          (define-syntax- f
-            (make-rename-transformer (⊢ f- : (→ ty ... ty_out))))
+          (define-typed-variable-rename f ≫ f- : (→ ty ... ty_out))
           (stlc+union+case:define f-
             (stlc+union+case:λ ([x : ty] ...) e)))]])
 

--- a/turnstile/examples/rosette/rosette2.rkt
+++ b/turnstile/examples/rosette/rosette2.rkt
@@ -174,7 +174,7 @@
    #:with (y ...) (generate-temporaries #'(x ...))
    --------
    [_ ≻ (begin-
-          (define-syntax- x (make-rename-transformer (⊢ y : ty.norm))) ...
+          (define-typed-variable-rename x ≫ y : ty.norm)
           (ro:define-symbolic y ... pred-))]])
 
 (define-typed-syntax define-symbolic*
@@ -184,7 +184,7 @@
    #:with (y ...) (generate-temporaries #'(x ...))
    --------
    [_ ≻ (begin-
-          (define-syntax- x (make-rename-transformer (⊢ y : ty.norm))) ...
+          (define-typed-variable-rename x ≫ y : ty.norm)
           (ro:define-symbolic* y ... pred-))]])
 
 ;; TODO: support internal definition contexts
@@ -247,8 +247,7 @@
    #:with f- (generate-temporary #'f)
    --------
    [_ ≻ (begin-
-          (define-syntax- f
-            (make-rename-transformer (⊢ f- : (C→ ty ... ty_out))))
+          (define-typed-variable-rename f ≫ f- : (C→ ty ... ty_out))
           (ro:define f-
             (stlc:λ ([x : ty] ...) (ann (begin e ...) : ty_out))))]])
 

--- a/turnstile/examples/trivial.rkt
+++ b/turnstile/examples/trivial.rkt
@@ -283,13 +283,11 @@
    #:with (X ...) (generate-temporaries #'(x ...))
    [([X ≫ X- :: #%type] ...) ([x ≫ x- : X] ...) 
     ⊢ (begin . es) ≫ e- ⇒ τ_out]
-   ;; TODO: investigate why this extra syntax-local-introduce is needed?
-   #:with τ_out* (syntax-local-introduce #'τ_out)
-   #:with (~or (~CCs Ys Cs Bs τ_out**) 
-               (~and τ_out**
+   #:with (~or (~CCs Ys Cs Bs τ_out*) 
+               (~and τ_out*
                      (~parse (Ys Cs Bs)
                              #'(() (#%app void) (#%app void)))))
-           #'τ_out*
+           #'τ_out
 ;   #:when (begin (displayln "Bs:")
 ;                 (stx-map 
 ;                  (compose pretty-print syntax->datum)
@@ -312,7 +310,7 @@
 ;             (syntax->datum #'(→- Ys Cs ty-arg ... τ_out**))))
    -------
    [⊢ (tr:λ ([x- tr:: ty] ...) e-) 
-      ⇒ (→- Ys Cs ty-arg ... τ_out**)]])
+      ⇒ (→- Ys Cs ty-arg ... τ_out*)]])
 
 ;; #%app --------------------------------------------------------------------
 (define-typed-syntax app/tc
@@ -382,20 +380,18 @@
 (define-typed-syntax define
   [(_ x:id e) ≫
    [⊢ e ≫ e- ⇒ ty]
-   #:with x* (generate-temporary)
+   #:with x- (generate-temporary)
    ----------
    [≻ (begin-
-        (tr:define-syntax x
-          (make-rename-transformer (⊢ x* : ty)))
-        (tr:define x* e-))]]   
+        (define-typed-variable-rename x ≫ x- : ty)
+        (tr:define x- e-))]]   
   [(_ (f b ...) . es) ≫
    [⊢ (λ (b ...) (begin . es)) ≫ fn- ⇒ ty-f]
-   #:with g (generate-temporary #'f)
+   #:with f- (generate-temporary #'f)
    --------
    [≻ (begin-
-        (tr:define-syntax f
-          (make-rename-transformer (⊢ g : ty-f)))
-        (tr:define g fn-))]])
+        (define-typed-variable-rename f ≫ f- : ty-f)
+        (tr:define f- fn-))]])
 
 (define-typed-syntax begin
   [(_ e_unit ... e) ≫

--- a/turnstile/scribblings/reference.scrbl
+++ b/turnstile/scribblings/reference.scrbl
@@ -258,10 +258,10 @@ For example, here is a basic typed version of @racket[define]:
    #:with y (generate-temporary #'x)
    --------
    [≻ (begin-
-        (define-syntax x (make-rename-transformer (⊢ y : τ)))
+        (define-typed-variable-rename x ≫ y : τ)
         (define- y e-))]])]
 
-This macro creates an indirection @racket[make-rename-transformer] in order to
+This macro creates an indirection @racket[define-typed-variable-rename] in order to
 attach type information to the top-level @tt{x} identifier, so the
 @racket[define] forms themselves do not need type information.}
 
@@ -283,6 +283,15 @@ Aliases for @racket[define-typed-syntax].}
 A @racket[syntax-parse]-like form that supports
 @racket[define-typed-syntax]-style clauses. In particular, see the
 "rule" part of @racket[define-typed-syntax]'s grammar above.}
+
+
+@; define-typed-variable-rename -----------------------------------------------
+
+@defform[(define-typed-variable-rename typed-var ≫ untyped-var : type)]
+
+Defines @racket[typed-var] as a variable with type @racket[type] that erases to
+@racket[untyped-var]. Supports @racket[set!]. Generally typed definition
+forms will expand to a combination of an untyped @racket[define] and this form.
 
 
 @; define-primop --------------------------------------------------------------


### PR DESCRIPTION
    Have assign-type wrap with `erased`, for stop-list
    
    This prevents local expansion from expanding erased terms at all until
    typechecking is complete. As opposed to the earlier stop-list
    implementation, this should properly support erasing to forms that
    communicate with side effects and syntax parameters.
    
    Typed define forms should now use `define-typed-variable-rename`, which
    avoids wrapping for this case in order to make `set!` work.
    
    Note that erasing to another turnstile language will currently *not*
    work, because the leftover `erased` forms will prevent typechecking
    within the target language.
