### PR TITLE
Enhancements to `type-error` form

### DIFF
--- a/macrotypes-lib/macrotypes/typecheck-core.rkt
+++ b/macrotypes-lib/macrotypes/typecheck-core.rkt
@@ -1225,8 +1225,13 @@
      (exn:fail:type:check
       (format (string-append "TYPE-ERROR: ~a (~a:~a): " msg) 
               (syntax-source stx-src) (syntax-line stx-src) (syntax-column stx-src) 
-              (type->str args) ...)
+              (type-or-datum->str args) ...)
       contmarks)))
+
+  (define (type-or-datum->str arg)
+    (if (syntax? arg)
+        (type->str arg)
+        (format "~s" arg)))
 
   ;; --------------------------------------------------------------------------
   ;; orig property tracks surface term, for err reporting

--- a/macrotypes-test/tests/macrotypes/typecheck-core.rkt
+++ b/macrotypes-test/tests/macrotypes/typecheck-core.rkt
@@ -60,7 +60,7 @@
     (test-case "message with interpolated syntax"
       (check-exn #rx"^TYPE-ERROR:.*: 6 [(]vec int[)]$"
                  (λ () (type-error #:src #'e #:msg "~a ~a" #'6 #'(vec int)))))
-    (test-case "raises contract error when args aren't syntax"
-      (check-exn #rx"^syntax-property: contract violation"
+    (test-case "message with interpolated datum and syntax"
+      (check-exn #rx"^TYPE-ERROR:.*: 6 [(]vec int[)]$"
                  (λ () (type-error #:src #'e #:msg "~a ~a" 6 #'(vec int))))))
   )

--- a/macrotypes-test/tests/macrotypes/typecheck-core.rkt
+++ b/macrotypes-test/tests/macrotypes/typecheck-core.rkt
@@ -52,4 +52,15 @@
       (check-equal? (variance-compose contravariant contravariant) covariant)
       (check-equal? (variance-compose contravariant irrelevant) irrelevant)
       (check-equal? (variance-compose contravariant invariant) invariant)))
+  (test-case "type-error"
+    (test-case "simple message"
+      (check-exn #rx"^TYPE-ERROR:.*: the message$"
+                 (λ () (type-error #:src #'e
+                                   #:msg "the message"))))
+    (test-case "message with interpolated syntax"
+      (check-exn #rx"^TYPE-ERROR:.*: 6 [(]vec int[)]$"
+                 (λ () (type-error #:src #'e #:msg "~a ~a" #'6 #'(vec int)))))
+    (test-case "raises contract error when args aren't syntax"
+      (check-exn #rx"^syntax-property: contract violation"
+                 (λ () (type-error #:src #'e #:msg "~a ~a" 6 #'(vec int))))))
   )


### PR DESCRIPTION
I’ve been wanting to produce type errors procedurally and found the
`type-error` form lacking. I imagine I’m not alone, given that there’s a
comment on [its definition][type-error definition]: “deprecate this? can
we rely on stx-parse instead?” I’ve been defining my own `type-error` in
terms of `raise-syntax-error`, but this PR is an attempt to make the
library’s `type-error` more useful.

For reference, the syntax is:

```racket
    (type-error #:src src #:msg msg args ...)
```

where `src` a syntax object, and `msg` is a format string with a hole
for each of `args ...`.

The largest change is that `type-error` now throws a new struct
`exn:fail:syntax:type-check`, which inherits from `exn:fail:syntax` with
no additional fields. This replaces `exn:fail:type:check`, which
inherited from `exn:fail:user`. The new struct has an additional field
`exn:fail:syntax-exprs` that holds a list of syntax objects and makes it
available via `prop:exn:srclocs`. The `type-check` form fills this field
based on its parameters, which means that DrRacket now highlights and
jumps to type errors raised with `type-error` automatically. To go along
with this, `type-error` no longer includes textual representation
of the source location in the error message.

Details:

  - `type-error` no longer requires `args ...` to evaluate to syntax
    objects. The documentation didn’t say that the arguments were
    expected to be syntax objects, and it’s pretty useful for them not
    to be, so now `type-error` applies `type->str` only to arguments
    that need it and `~s` to the rest.

  - The list of source locations starts with the value of `src`. That’s
    followed by only the `args ...` that evaluate to *original* syntax
    objects.

  - All of the above is tested.

[type-error definition]:
    https://github.com/stchang/macrotypes/blob/02845cfff575fe533158f5dd7db564ddd94f187b/macrotypes-lib/macrotypes/typecheck-core.rkt#L1217