### PR TITLE
Fix DrRacket binding arrows on fresh vars

### DIFF
--- a/macrotypes-lib/macrotypes/stx-utils.rkt
+++ b/macrotypes-lib/macrotypes/stx-utils.rkt
@@ -113,7 +113,7 @@
 
 ; alternate to generate-temporaries, which relies on symbolic name
 (define (fresh id)
-  ((make-syntax-introducer) (datum->syntax #f (syntax-e id))))
+  (replace-stx-loc ((make-syntax-introducer) (datum->syntax #f (syntax-e id))) id))
 
 (define (id-lower-case? stx)
   (unless (identifier? stx)

--- a/macrotypes-lib/macrotypes/stx-utils.rkt
+++ b/macrotypes-lib/macrotypes/stx-utils.rkt
@@ -113,7 +113,10 @@
 
 ; alternate to generate-temporaries, which relies on symbolic name
 (define (fresh id)
-  (replace-stx-loc ((make-syntax-introducer) (datum->syntax #f (syntax-e id))) id))
+  (syntax-property
+   (replace-stx-loc ((make-syntax-introducer) (datum->syntax #f (syntax-e id))) id)
+   'original-for-check-syntax
+   #t))
 
 (define (id-lower-case? stx)
   (unless (identifier? stx)

--- a/macrotypes-lib/macrotypes/typecheck-core.rkt
+++ b/macrotypes-lib/macrotypes/typecheck-core.rkt
@@ -32,7 +32,7 @@
 (define-syntax (erased stx)
   (syntax-parse stx
     [(_ e)
-     #'e]))
+     (replace-stx-loc #'e this-syntax)]))
 
 ;; type checking functions/forms
 


### PR DESCRIPTION
This partially fixes binding arrows in DrRacket:
- Hovering over a binder in a Turnstile language now points to all bound identifiers.
- Hovering over a bound identifier points to the binder

However, when hovering over a bound identifier, you also get a backwards red arrow to a left paren whose origin and meaning I cannot yet discern.

Requires #88 