### PR TITLE
It's useful to call typeof when not syntax-transforming?.

### DIFF
--- a/macrotypes-lib/macrotypes/typecheck-core.rkt
+++ b/macrotypes-lib/macrotypes/typecheck-core.rkt
@@ -248,7 +248,10 @@
   ;; If Val is a non-empty list, return first element, otherwise return Val.
   ;; e.g., Stx = expression, Tag = ':, Val = Type stx
   (define (detach stx tag)
-    (intro-if-stx (get-stx-prop/ca*r stx tag))))
+    ; NB: Only intro-if-stx while the expander is running.
+    ; This allows calling typeof, e.g., in DrRacket expansion handler.
+    ((if (syntax-transforming?) intro-if-stx values)
+     (get-stx-prop/ca*r stx tag))))
 
 ;; ----------------------------------------------------------------------------
 ;; ----------------------------------------------------------------------------


### PR DESCRIPTION
Avoid using syntax-local-introduce in detach when not syntax-transforming?, so
typeof can be used to detach types during other times.