### PR TITLE
Correct version number

### DIFF
--- a/turnstile-lib/info.rkt
+++ b/turnstile-lib/info.rkt
@@ -12,4 +12,4 @@
 (define pkg-desc "A language for defining type systems as macros.")
 (define pkg-authors '(stchang))
 
-(define version "0.4.9")
+(define version "0.4.10")


### PR DESCRIPTION
Looks like a version number got lost in the rebase. This is the one that cur expects, and must have been correct before the rebase.