### PR TITLE
Expose new define-internal-*-type macros

### DIFF
--- a/macrotypes-lib/HISTORY.txt
+++ b/macrotypes-lib/HISTORY.txt
@@ -2,3 +2,5 @@ Revision history for macrotypes-lib
 
 0.3.2 (2018-11-14)
 - var-assign function: first arg is unexpanded var
+0.3.3 (2019-03-25)
+- add current-resugar (generalizes type->str)

--- a/macrotypes-lib/info.rkt
+++ b/macrotypes-lib/info.rkt
@@ -8,4 +8,4 @@
 (define pkg-desc "A library for defining type systems as macros.")
 (define pkg-authors '(stchang))
 
-(define version "0.3.2")
+(define version "0.3.3")

--- a/macrotypes-lib/macrotypes/stx-utils.rkt
+++ b/macrotypes-lib/macrotypes/stx-utils.rkt
@@ -114,7 +114,10 @@
 
 ; alternate to generate-temporaries, which relies on symbolic name
 (define (fresh id)
-  (replace-stx-loc ((make-syntax-introducer) (datum->syntax #f (syntax-e id))) id))
+  (syntax-property
+   (replace-stx-loc ((make-syntax-introducer) (datum->syntax #f (syntax-e id))) id)
+   'original-for-check-syntax
+   #t))
 
 (define (id-lower-case? stx)
   (unless (identifier? stx)

--- a/macrotypes-lib/macrotypes/stx-utils.rkt
+++ b/macrotypes-lib/macrotypes/stx-utils.rkt
@@ -2,7 +2,8 @@
 (require syntax/stx syntax/parse syntax/parse/define
          racket/list racket/format version/utils
          racket/syntax)
-(provide (all-defined-out))
+(provide (all-defined-out)
+         (rename-out [stx-datum-equal? datum=?]))
 
 ;; shorthands
 (define id? identifier?)

--- a/macrotypes-lib/macrotypes/typecheck-core.rkt
+++ b/macrotypes-lib/macrotypes/typecheck-core.rkt
@@ -1171,16 +1171,16 @@
   ;; typecheck-fail-msg/1 : Type Type Stx -> String
   (define (typecheck-fail-msg/1 τ_expected τ_given expression)
     (format "type mismatch: expected ~a, given ~a\n  expression: ~s"
-            (type->str τ_expected)
-            (or (and (syntax-e τ_given) (type->str τ_given))
+            ((current-resugar) τ_expected)
+            (or (and (syntax-e τ_given) ((current-resugar) τ_given))
                 "an invalid expression")
             (syntax->datum (get-orig expression))))
 
   ;; typecheck-fail-msg/1/no-expr : Type Type Stx -> String
   (define (typecheck-fail-msg/1/no-expr τ_expected τ_given)
     (format "type mismatch: expected ~a, given ~a"
-            (type->str τ_expected)
-            (type->str τ_given)))
+            ((current-resugar) τ_expected)
+            ((current-resugar) τ_given)))
 
   ;; typecheck-fail-msg/multi : (Stx-Listof Type) (Stx-Listof Type) (Stx-Listof Stx) -> String
   (define (typecheck-fail-msg/multi τs_expected τs_given expressions)
@@ -1188,8 +1188,8 @@
                            "  expected:    ~a\n"
                            "  given:       ~a\n"
                            "  expressions: ~a")
-            (string-join (stx-map type->str τs_expected) ", ")
-            (string-join (stx-map type->str τs_given) ", ")
+            (string-join (stx-map (current-resugar) τs_expected) ", ")
+            (string-join (stx-map (current-resugar) τs_given) ", ")
             (string-join (map ~s (stx-map syntax->datum expressions)) ", ")))
 
   ;; typecheck-fail-msg/multi/no-exprs : (Stx-Listof Type) (Stx-Listof Type) -> String
@@ -1197,8 +1197,8 @@
     (format (string-append "type mismatch\n"
                            "  expected:    ~a\n"
                            "  given:       ~a")
-            (string-join (stx-map type->str τs_expected) ", ")
-            (string-join (stx-map type->str τs_given) ", ")))
+            (string-join (stx-map (current-resugar) τs_expected) ", ")
+            (string-join (stx-map (current-resugar) τs_given) ", ")))
 
   ;; no-expected-type-fail-msg : -> String
   (define (no-expected-type-fail-msg)
@@ -1211,7 +1211,7 @@
                            "  arguments: ~a")
             (syntax->datum (get-orig fn))
             (stx-length τs_expected) (stx-length arguments)
-            (string-join (stx-map type->str τs_expected) ", ")
+            (string-join (stx-map (current-resugar) τs_expected) ", ")
             (string-join (map ~s (map syntax->datum (stx-map get-orig arguments))) ", ")))
 
   (struct exn:fail:syntax:type-check exn:fail:syntax ())
@@ -1236,7 +1236,7 @@
       (cons stx-src (filter original-syntax? args)))))
 
   (define (type-or-datum->str arg)
-    (if (syntax? arg) (type->str arg) (~s arg)))
+    (if (syntax? arg) ((current-resugar) arg) (~s arg)))
 
   (define (original-syntax? arg)
     (and (syntax? arg) (syntax-original? arg)))
@@ -1264,10 +1264,13 @@
                                   #:before-first "("
                                   #:after-last ")")]
       [else (format "~s" (syntax->datum τ))]))
-  (define (types->str tys #:sep [sep ", "])
-    (string-join (stx-map type->str tys) sep))
 
-  ;; --------------------------------------------------------------------------
+  (define current-resugar (make-parameter type->str))
+  
+  (define (types->str tys #:sep [sep ", "])
+    (string-join (stx-map (current-resugar) tys) sep))
+    
+;; --------------------------------------------------------------------------
   ;; misc helpers
   (define (brace? stx)
     (define paren-shape/#f (syntax-property stx 'paren-shape))

--- a/turnstile-example/info.rkt
+++ b/turnstile-example/info.rkt
@@ -5,10 +5,10 @@
 (define deps
   '(("base" #:version "7.0")
     "typed-racket-lib"
-    ("turnstile-lib" #:version "0.3.6")
-    ("macrotypes-lib" #:version "0.3.2")))
+    ("turnstile-lib" #:version "0.4.2")
+    ("macrotypes-lib" #:version "0.4.2")))
 
 (define pkg-desc "Example languages for \"turnstile\".")
 (define pkg-authors '(stchang))
 
-(define version "0.3.6")
+(define version "0.4.2")

--- a/turnstile-example/info.rkt
+++ b/turnstile-example/info.rkt
@@ -5,10 +5,10 @@
 (define deps
   '(("base" #:version "7.0")
     "typed-racket-lib"
-    ("turnstile-lib" #:version "0.4.2")
-    ("macrotypes-lib" #:version "0.3.2")))
+    ("turnstile-lib" #:version "0.4.9")
+    ("macrotypes-lib" #:version "0.3.3")))
 
 (define pkg-desc "Example languages for \"turnstile\".")
 (define pkg-authors '(stchang))
 
-(define version "0.4.2")
+(define version "0.4.3")

--- a/turnstile-example/info.rkt
+++ b/turnstile-example/info.rkt
@@ -6,7 +6,7 @@
   '(("base" #:version "7.0")
     "typed-racket-lib"
     ("turnstile-lib" #:version "0.4.2")
-    ("macrotypes-lib" #:version "0.4.2")))
+    ("macrotypes-lib" #:version "0.3.2")))
 
 (define pkg-desc "Example languages for \"turnstile\".")
 (define pkg-authors '(stchang))

--- a/turnstile-example/turnstile/examples/dep/dep-ind-cur2+data.rkt
+++ b/turnstile-example/turnstile/examples/dep/dep-ind-cur2+data.rkt
@@ -1,5 +1,5 @@
 #lang turnstile/lang
-(require (except-in "dep-ind-cur2.rkt" λ #%app)
+(require (except-in "dep-ind-cur2.rkt" λ #%app Π)
          "dep-ind-cur2+sugar.rkt"
          turnstile/eval turnstile/typedefs turnstile/more-utils)
 

--- a/turnstile-example/turnstile/examples/dep/dep-ind-cur2+data.rkt
+++ b/turnstile-example/turnstile/examples/dep/dep-ind-cur2+data.rkt
@@ -120,8 +120,9 @@
    #:with elim-TY (format-id #'TY "elim-~a" #'TY)
    #:with eval-TY (format-id #'TY "eval-~a" #'TY)
    #:with TY/internal (generate-temporary #'TY)
-   #:with (C-expander ...) (stx-map mk-~ #'(C ...))
-;   #:with TY-expander (mk-~ #'TY)
+   #:with (C-pat ...) (for/list ([C-expander (stx-map mk-~ #'(C ...))]
+                                 [xs (stx->list #'((x ...) ...))])
+                        (if (stx-null? xs) C-expander #`(#,C-expander . #,xs)))
    --------
    [≻ (begin-
         ;; define the type, eg "Nat"
@@ -133,7 +134,6 @@
         ;; elimination form
         (define-typerule/red (elim-TY v P m ...) ≫
           [⊢ v ≫ v- ⇐ TY]
-;          [⊢ v ≫ v- ⇒ TY-expander]
           [⊢ P ≫ P- ⇐ (→ TY Type)] ; prop / motive
           ;; each `m` can consume 2 sets of args:
           ;; 1) args of the constructor `x` ... 
@@ -144,7 +144,7 @@
           -----------
           [⊢ (eval-TY v- P- m- ...) ⇒ (P- v-)]
           #:where eval-TY ; elim reduction rule
-          [(#%plain-app (C-expander x ...) P m ...) ; elim redex
+          [(#%plain-app C-pat P m ...) ; elim redex
            ~> (app/eval m x ... (eval-TY xrec P m ...) ...)] ...)
         )]]
   ;; --------------------------------------------------------------------------
@@ -199,7 +199,9 @@
    #:with elim-TY (format-id #'TY "elim-~a" #'TY)
    #:with eval-TY (format-id #'TY "match-~a" #'TY)
    #:with (τm ...) (generate-temporaries #'(m ...))
-   #:with (C-expander ...) (stx-map mk-~ #'(C ...))
+   #:with (C-pat ...) (for/list ([C-expander (stx-map mk-~ #'(C ...))]
+                                 [xs (stx->list #'((CA ... i+x ...) ...))])
+                        (if (stx-null? xs) C-expander #`(#,C-expander . #,xs)))
    ;; these are all the generated definitions that implement the define-datatype
    #:with OUTPUT-DEFS
     #'(begin-
@@ -267,7 +269,7 @@
           -----------
           [⊢ (eval-TY v- P- m- ...) ⇒ (P- i ... v-)]
           #:where eval-TY ; elim reduction rule
-          [(#%plain-app (C-expander CA ... i+x ...) P m ...) ; elim redex
+          [(#%plain-app C-pat P m ...) ; elim redex
            ~> (app/eval m i+x ... (eval-TY xrec P m ...) ...)] ...)
         )
    --------

--- a/turnstile-example/turnstile/examples/dep/dep-ind-cur2+data2.rkt
+++ b/turnstile-example/turnstile/examples/dep/dep-ind-cur2+data2.rkt
@@ -1,5 +1,5 @@
 #lang turnstile/lang
-(require (except-in "dep-ind-cur2.rkt" λ #%app)
+(require (except-in "dep-ind-cur2.rkt" λ #%app Π)
          "dep-ind-cur2+sugar.rkt"
          (only-in "dep-ind-cur2+data.rkt" [define-datatype define-datatype1])
          turnstile/eval turnstile/typedefs turnstile/more-utils)

--- a/turnstile-example/turnstile/examples/dep/dep-ind-cur2+sugar.rkt
+++ b/turnstile-example/turnstile/examples/dep/dep-ind-cur2+sugar.rkt
@@ -1,19 +1,35 @@
 #lang turnstile/lang
 (require turnstile/more-utils
+         (for-syntax turnstile/more-utils)
          "dep-ind-cur2.rkt")
 
 ;; dep-ind-cur2 library, adding some sugar like auto-currying
 
-(provide → ∀ (rename-out [λ/c λ] [app/c #%app] [app/eval/c app/eval]))
+(provide → ∀ (for-syntax ~Π)
+ (rename-out [Π/c Π] [λ/c λ] [app/c #%app] [app/eval/c app/eval]))
+
+(define-nested/R Π/c Π)
+
+(begin-for-syntax
+  ;; curried expander
+  (define-syntax ~Π
+    (pattern-expander
+     (syntax-parser
+       [(_ t) #'t]
+       [(_ (~var b x+τ) (~and (~literal ...) ooo) t_out)
+        #'(~and ty-to-match
+                (~parse
+                 ([b.x (~datum :) b.τ] ooo t_out)
+                 (stx-parse/fold #'ty-to-match (~Π/1 b rst))))]))))
 
 ;; abbrevs for Π/c
 ;; (→ τ_in τ_out) == (Π (unused : τ_in) τ_out)
 (define-simple-macro (→ τ_in ... τ_out)
   #:with (X ...) (generate-temporaries #'(τ_in ...))
-  (Π [X : τ_in] ... τ_out))
+  (Π/c [X : τ_in] ... τ_out))
 ;; (∀ (X) τ) == (∀ ([X : Type]) τ)
 (define-simple-macro (∀ X ...  τ)
-  (Π [X : Type] ... τ))
+  (Π/c [X : Type] ... τ))
 
 (define-nested/R λ/c λ)
 (define-nested/L app/c #%app)

--- a/turnstile-example/turnstile/examples/dep/dep-ind-cur2.rkt
+++ b/turnstile-example/turnstile/examples/dep/dep-ind-cur2.rkt
@@ -9,7 +9,7 @@
 ; Π  λ ≻ ⊢ ≫ → ∧ (bidir ⇒ ⇐) τ⊑ ⇑
 
 (provide Type (rename-out [Type *]) (for-syntax ~Type) TypeTop
-         Π (for-syntax ~Π ~Π/1)
+         (rename-out [Π/1 Π]) (for-syntax ~Π/1)
          (rename-out [λ/1 λ] [app #%app] [app/eval app/eval/1])
          ann define provide module* submod for-syntax begin-for-syntax)
 
@@ -56,7 +56,7 @@
 (define-syntax TypeTop (make-variable-like-transformer #'(Type 99)))
 
 ;; old Π/c now Π, old Π now Π/1
-(define-type Π #:with-binders ([X : TypeTop] #:telescope) : TypeTop -> Type)
+(define-type Π/1 #:with-binders [X : TypeTop] : TypeTop -> Type)
 
 ;; type check relation --------------------------------------------------------
 ;; - must come after type defs

--- a/turnstile-example/turnstile/examples/dep/dep-ind-cur2.rkt
+++ b/turnstile-example/turnstile/examples/dep/dep-ind-cur2.rkt
@@ -19,7 +19,7 @@
 
 ;; set (Type n) : (Type n+1)
 ;; Type = (Type 0)
-(struct Type- (n) #:transparent) ; runtime representation
+(struct Type- (n) #:transparent #:omit-define-syntaxes) ; runtime representation
 (begin-for-syntax
   (define Type-id (expand/df #'Type-))
   (define-syntax ~Type
@@ -33,8 +33,13 @@
             (~and C:id (~fail #:unless (free-identifier=? #'C Type-id)
                               (format "type mismatch, expected Type, given ~a"
                                       (syntax->datum #'C))))
-            ((~literal quote) n)))]
-       ))))
+            ((~literal quote) n)))])))
+  (define Type-
+    (type-info
+     #f ; match info
+     (syntax-parser [(~Type n) #'(Type n)]) ; resugar
+     (syntax-parser [(~Type n) #'(Type n)]))) ; unexpand
+  )
 
 (define-typed-syntax Type
   [:id ≫ --- [≻ (Type 0)]]

--- a/turnstile-lib/HISTORY.txt
+++ b/turnstile-lib/HISTORY.txt
@@ -1,5 +1,8 @@
 Revision history for turnstile-lib
 
+0.3.1 (2018-10-19)
+- split packages into macrotypes-lib, turnstile-lib, etc
+
 0.3.2 (2018-11-14)
 - `typed-variable-syntax` input pattern(s) must have shape (_ x ≫ x- : τ)
 
@@ -15,3 +18,19 @@ Revision history for turnstile-lib
 
 0.3.6 (2018-12-05)
 - add turnstile/no-unicode
+
+0.4.2 (2018-10-26)
+- turnstile/typedefs:
+  - separate (and simplify) representations for binding and non-binding types
+- start of `cur` branch
+
+0.4.3 (2018-10-26)
+- turnstile/typedefs:
+  - generalize "extra" info to extensible type-info struct, currently:
+    - match info (ie, the old "extra" info)
+    - resugar fn
+
+0.4.4 (2018-10-31)
+- turnstile/eval: define-red supports #:display-as name
+- turnstile/typedefs:
+  - resugar-type supports app and lambda terms, and uses display-as name

--- a/turnstile-lib/HISTORY.txt
+++ b/turnstile-lib/HISTORY.txt
@@ -37,3 +37,6 @@ Revision history for turnstile-lib
 
 0.4.5 (2018-11-01)
 - turnstile/eval: define-red output macro expands all, not just head
+
+0.4.6 (2018-11-06)
+- turnstile/typedefs: more resugar options for binding types: 'display-as, 'tmp

--- a/turnstile-lib/HISTORY.txt
+++ b/turnstile-lib/HISTORY.txt
@@ -43,3 +43,8 @@ Revision history for turnstile-lib
 
 0.4.7 (2018-11-16)
 - add turnstile/type-constraints for turnstile/typedefs type defs
+
+0.4.8 (2018-11-27)
+- turnstile/typedefs: split out define-base-type
+  - only allow id case in pattern expander
+  - disallow nullary application to disambiguate certain cases

--- a/turnstile-lib/HISTORY.txt
+++ b/turnstile-lib/HISTORY.txt
@@ -48,3 +48,6 @@ Revision history for turnstile-lib
 - turnstile/typedefs: split out define-base-type
   - only allow id case in pattern expander
   - disallow nullary application to disambiguate certain cases
+
+0.4.9 (2019-03-25)
+- turnstile: use current-resugar

--- a/turnstile-lib/HISTORY.txt
+++ b/turnstile-lib/HISTORY.txt
@@ -34,3 +34,6 @@ Revision history for turnstile-lib
 - turnstile/eval: define-red supports #:display-as name
 - turnstile/typedefs:
   - resugar-type supports app and lambda terms, and uses display-as name
+
+0.4.5 (2018-11-01)
+- turnstile/eval: define-red output macro expands all, not just head

--- a/turnstile-lib/HISTORY.txt
+++ b/turnstile-lib/HISTORY.txt
@@ -40,3 +40,6 @@ Revision history for turnstile-lib
 
 0.4.6 (2018-11-06)
 - turnstile/typedefs: more resugar options for binding types: 'display-as, 'tmp
+
+0.4.7 (2018-11-16)
+- add turnstile/type-constraints for turnstile/typedefs type defs

--- a/turnstile-lib/info.rkt
+++ b/turnstile-lib/info.rkt
@@ -12,4 +12,4 @@
 (define pkg-desc "A language for defining type systems as macros.")
 (define pkg-authors '(stchang))
 
-(define version "0.4.7")
+(define version "0.4.8")

--- a/turnstile-lib/info.rkt
+++ b/turnstile-lib/info.rkt
@@ -4,7 +4,7 @@
 
 (define deps
   '(("base" #:version "7.0")
-    ("macrotypes-lib" #:version "0.3.2")
+    ("macrotypes-lib" #:version "0.3.3")
     "lens-lib"))
 
 (define build-deps '())
@@ -12,4 +12,4 @@
 (define pkg-desc "A language for defining type systems as macros.")
 (define pkg-authors '(stchang))
 
-(define version "0.4.8")
+(define version "0.4.9")

--- a/turnstile-lib/info.rkt
+++ b/turnstile-lib/info.rkt
@@ -12,4 +12,4 @@
 (define pkg-desc "A language for defining type systems as macros.")
 (define pkg-authors '(stchang))
 
-(define version "0.3.6")
+(define version "0.4.6")

--- a/turnstile-lib/info.rkt
+++ b/turnstile-lib/info.rkt
@@ -12,4 +12,4 @@
 (define pkg-desc "A language for defining type systems as macros.")
 (define pkg-authors '(stchang))
 
-(define version "0.4.9")
+(define version "0.4.10")

--- a/turnstile-lib/info.rkt
+++ b/turnstile-lib/info.rkt
@@ -12,4 +12,4 @@
 (define pkg-desc "A language for defining type systems as macros.")
 (define pkg-authors '(stchang))
 
-(define version "0.4.6")
+(define version "0.4.7")

--- a/turnstile-lib/turnstile/eval.rkt
+++ b/turnstile-lib/turnstile/eval.rkt
@@ -51,32 +51,28 @@
     ;; eg, see `zero?` in stdlib/nat
     [(_ red-name
         (~optional (~seq #:display-as orig) #:defaults ([orig #'red-name]))
-        [(placeholder head-pat . rst-pat) (~datum ~>) contractum] ...+)
+        [(placeholder . pats) (~datum ~>) contractum] ...+)
      #:with placeholder1 (stx-car #'(placeholder ...))
      #'(define-syntax red-name
-         (syntax-parser
-           [(_ head . rst-pat2)
-            #:with saved-stx this-syntax
-            (transfer-type
-             this-syntax
-             (syntax-parse #`(#,(expand/df #'head) . rst-pat2)
-               [(head-pat . rst-pat)
-                ;; #:do[(displayln 'red-name)
-                ;;      (pretty-print (stx->datum this-syntax))
-                ;;      (displayln '~>)
-                ;;      (pretty-print (stx->datum #`contractum))]
-                (reflect #`contractum)] ...
-               [es
-                ;; #:do[(display "no match: ") (displayln 'red-name)
-                ;;                      (pretty-print (stx->datum #'es))
-                ;;                      (displayln 'head)
-                ;;                      (pretty-print (stx->datum #'head))
-                ;;                      (displayln 'otherpats)
-                ;;                      (stx-map
-                ;;                       (λ (ps) (pretty-print (stx->datum ps)))
-                ;;                       #'((head-pat . rst-pat) ...))]
-                (quasisyntax/loc #'saved-stx
-                  (#,(mk-reflected #'red-name #'placeholder1 #'orig) . es))]))]))]))
+         (λ (stx)
+           (transfer-type
+            stx
+            (syntax-parse (stx-map expand/df (stx-cdr stx)) ; drop macro name
+              [pats
+               ;; #:do[(displayln 'red-name)
+               ;;      (pretty-print (stx->datum this-syntax))
+               ;;      (displayln '~>)
+               ;;      (pretty-print (stx->datum #`contractum))]
+               (reflect #`contractum)] ...
+              [es
+               ;; #:do[(display "no match: ") (displayln 'red-name)
+               ;;                      (pretty-print (stx->datum #'es))
+               ;;                      (displayln 'expected)
+               ;;                      (stx-map
+               ;;                       (λ (ps) (pretty-print (stx->datum ps)))
+               ;;                       #'(pats ...))]
+               (quasisyntax/loc stx
+                 (#,(mk-reflected #'red-name #'placeholder1 #'orig) . es))]))))]))
 
 ;; use #%plain-app for now
 (define-syntax define-core-id

--- a/turnstile-lib/turnstile/eval.rkt
+++ b/turnstile-lib/turnstile/eval.rkt
@@ -72,7 +72,7 @@
                 ;;                       #'((head-pat . rst-pat) ...))]
                 (quasisyntax/loc #'saved-stx (#,(mk-reflected #'red-name #'placeholder1) . es))]))]))]))
 
-;; use #%plain-app for no
+;; use #%plain-app for now
 (define-syntax define-core-id
   (syntax-parser
     [(_ name:id) #'(define-core-id name #%plain-app)] ; plain-app is the default

--- a/turnstile-lib/turnstile/eval.rkt
+++ b/turnstile-lib/turnstile/eval.rkt
@@ -31,8 +31,11 @@
         #:except null)]
       [_ stx]))
 
-  (define (mk-reflected reflected-name [placeholder #'#%plain-app-])
-    (syntax-property placeholder 'reflect reflected-name))
+  (define (mk-reflected reflected-name placeholder [display-as #f])
+    (syntax-property
+     placeholder
+     'reflect
+     (syntax-property reflected-name 'display-as display-as)))
   )
 
 (define-syntax define-red
@@ -46,7 +49,9 @@
     ;;  bc it will already have parens in the stx-parse clauses below,
     ;; so the match will fail
     ;; eg, see `zero?` in stdlib/nat
-    [(_ red-name [(placeholder head-pat . rst-pat) (~datum ~>) contractum] ...+)
+    [(_ red-name
+        (~optional (~seq #:display-as orig) #:defaults ([orig #'red-name]))
+        [(placeholder head-pat . rst-pat) (~datum ~>) contractum] ...+)
      #:with placeholder1 (stx-car #'(placeholder ...))
      #'(define-syntax red-name
          (syntax-parser
@@ -70,7 +75,8 @@
                 ;;                      (stx-map
                 ;;                       (λ (ps) (pretty-print (stx->datum ps)))
                 ;;                       #'((head-pat . rst-pat) ...))]
-                (quasisyntax/loc #'saved-stx (#,(mk-reflected #'red-name #'placeholder1) . es))]))]))]))
+                (quasisyntax/loc #'saved-stx
+                  (#,(mk-reflected #'red-name #'placeholder1 #'orig) . es))]))]))]))
 
 ;; use #%plain-app for now
 (define-syntax define-core-id
@@ -82,12 +88,15 @@
 ;; combination of define-typerule and define-red
 (define-syntax define-typerule/red
   (syntax-parser
-    [(_ (name:id . in-pat) (~and rule (~not #:where)) ... #:where red-name reds ...+)
+    [(_ (name:id . in-pat) (~and rule (~not #:where)) ...
+        #:where red-name
+        (~optional (~seq #:display-as orig) #:defaults ([orig #'red-name]))
+        reds ...+)
      #:with name- (mk-- #'name)
      #`(begin-
          #,(quasisyntax/loc this-syntax
              (define-typerule (name . in-pat) rule ...))
          (define-core-id name-) ; a placeholder to use in the red rule
-         (define-red red-name reds ...))]))
+         (define-red red-name #:display-as orig reds ...))]))
 
 

--- a/turnstile-lib/turnstile/eval.rkt
+++ b/turnstile-lib/turnstile/eval.rkt
@@ -46,8 +46,10 @@
     ;; eg, see `zero?` in stdlib/nat
     [(_ red-name
         (~optional (~seq #:display-as orig) #:defaults ([orig #'#f]))
-        [(placeholder . pats) (~datum ~>) contractum] ...+)
-     #:with placeholder1 (stx-car #'(placeholder ...))
+        [(placeholder:id . pats) (~datum ~>) contractum] ...)
+     #:with placeholder1 (if (stx-null? #'(placeholder ...))
+                             #'#%plain-app
+                             (stx-car #'(placeholder ...)))
      #'(define-syntax red-name
          (λ (stx)
            (transfer-type
@@ -82,7 +84,7 @@
     [(_ (name:id . in-pat) (~and rule (~not #:where)) ...
         #:where red-name
         (~optional (~seq #:display-as orig) #:defaults ([orig #'#f]))
-        reds ...+)
+        (~and (~not #:display-as) reds) ...)
      #:with name- (mk-- #'name)
      #`(begin-
          #,(quasisyntax/loc this-syntax

--- a/turnstile-lib/turnstile/eval.rkt
+++ b/turnstile-lib/turnstile/eval.rkt
@@ -6,7 +6,7 @@
 
 (provide define-red
          define-typerule/red
-         (for-syntax reflect))
+         (for-syntax reflect mk-reflected))
 
 (begin-for-syntax
 

--- a/turnstile-lib/turnstile/eval.rkt
+++ b/turnstile-lib/turnstile/eval.rkt
@@ -10,15 +10,8 @@
 
 (begin-for-syntax
 
-  (define (transfer-type from to)
-    (define ty (typeof from))
-    (if ty
-        (syntax-property to ': (typeof from))
-        to))
-
   ;; reflects expanded stx to surface, so evaluation may continue
   (define (reflect stx)
-;    (printf "reflect: ~a\n" (syntax->datum stx))
     (syntax-parse stx
       [:id stx]
       [(m . rst)
@@ -33,9 +26,11 @@
 
   (define (mk-reflected reflected-name placeholder [display-as #f])
     (syntax-property
-     placeholder
-     'reflect
-     (syntax-property reflected-name 'display-as display-as)))
+     (syntax-property
+      placeholder
+      'reflect
+      reflected-name)
+     'display-as display-as))
   )
 
 (define-syntax define-red
@@ -50,7 +45,7 @@
     ;; so the match will fail
     ;; eg, see `zero?` in stdlib/nat
     [(_ red-name
-        (~optional (~seq #:display-as orig) #:defaults ([orig #'red-name]))
+        (~optional (~seq #:display-as orig) #:defaults ([orig #'#f]))
         [(placeholder . pats) (~datum ~>) contractum] ...+)
      #:with placeholder1 (stx-car #'(placeholder ...))
      #'(define-syntax red-name
@@ -66,11 +61,11 @@
                (reflect #`contractum)] ...
               [es
                ;; #:do[(display "no match: ") (displayln 'red-name)
-               ;;                      (pretty-print (stx->datum #'es))
-               ;;                      (displayln 'expected)
-               ;;                      (stx-map
-               ;;                       (λ (ps) (pretty-print (stx->datum ps)))
-               ;;                       #'(pats ...))]
+               ;;                             (pretty-print (stx->datum #'es))
+               ;;                             (displayln 'expected)
+               ;;                             (stx-map
+               ;;                              (λ (ps) (pretty-print (stx->datum ps)))
+               ;;                              #'(pats ...))]
                (quasisyntax/loc stx
                  (#,(mk-reflected #'red-name #'placeholder1 #'orig) . es))]))))]))
 
@@ -86,7 +81,7 @@
   (syntax-parser
     [(_ (name:id . in-pat) (~and rule (~not #:where)) ...
         #:where red-name
-        (~optional (~seq #:display-as orig) #:defaults ([orig #'red-name]))
+        (~optional (~seq #:display-as orig) #:defaults ([orig #'#f]))
         reds ...+)
      #:with name- (mk-- #'name)
      #`(begin-

--- a/turnstile-lib/turnstile/more-utils.rkt
+++ b/turnstile-lib/turnstile/more-utils.rkt
@@ -2,25 +2,28 @@
 
 ;; turnstile library of extra stx helpers
 
-(require syntax/parse
-         (for-syntax racket/base syntax/parse racket/syntax))
+(provide (for-syntax x+τ stx-parse/fold)
+         define-nested/R define-nested/L)
 
-(provide x+τ λ/c- #;~plain-app/c define-nested/R define-nested/L stx-parse/fold)
+(begin-for-syntax
+  ;; syntax class matching [x : τ], ie a parameter with type annotation
+  ;; TODO: generalize to arbitrary tags (not always :)?
+  (define-syntax-class x+τ
+    (pattern [(~var x id) (~datum :) τ]))
 
-#;(define-syntax ~plain-app/c
-  (pattern-expander
-   (syntax-parser
-     ;       [_ #:do[(displayln (stx->datum this-syntax))] #:when #f #'debugging]
-     [(_ f) #'f]
-     [(_ f e (~and (~literal ...) ooo))
-      #'(~and TMP
-              (~parse (f e ooo)
-                      (stx-parse/fold #'TMP ((~literal #%plain-app) x xs))))]
-     [(_ f e . rst)
-      #'(~plain-app/c ((~literal #%plain-app) f e) . rst)])))
-
-(define-syntax-class x+τ
-  (pattern [(~var x id) (~datum :) τ]))
+  ;; returns a flattened list of stx objs, outermost first
+  ;; usage: (stx-parse/fold stx pattern)
+  ;; - where pattern has shape (pexpander element remainder)
+  (define-syntax stx-parse/fold ; foldl
+    (syntax-parser
+      [(_ e (pexpander x rst))
+       #:with L (generate-temporary 'L)
+       #:with e-rst (generate-temporary #'e)
+       #:with acc (generate-temporary 'acc)
+       #`(let L ([e-rst e][acc null])
+           (syntax-parse e-rst
+             [(pexpander x rst) (L #'rst (cons #'x acc))]
+             [last (reverse (cons #'last acc))]))])))
 
 ;; R = like foldr, eg λ
 ;; L = like foldl, eg app
@@ -36,8 +39,9 @@
          (wrap-fn ; eg pattern-expander
           (syntax-parser
             [(_ e) #'e]
-            [(_ x . rst) (syntax/loc this-syntax (name/1 x (name . rst)))]
-            )))]))
+            [(_ x . rst)
+             (quasisyntax/loc this-syntax
+               (name/1 x #,(syntax/loc this-syntax (name . rst))))])))]))
 (define-syntax define-nested/L
   (syntax-parser
     [(_ name:id name/1) #'(define-nested/L name name/1 #:as (λ (x) x))]
@@ -46,31 +50,6 @@
          (wrap-fn
           (syntax-parser
             [(_ e) #'e]
-            [(_ f e . rst) (quasisyntax/loc this-syntax (name #,(syntax/loc this-syntax (name/1 f e)) . rst))]
-            )))]))
-
-;; returns a flattened list of stx objs, outermost first
-;; usage: (stx-parse/fold stx pattern)
-;; - where pattern has shape (pexpander element remainder)
-(define-syntax stx-parse/fold ; foldl
-  (syntax-parser
-    [(_ e (pexpander x rst))
-     #:with L (generate-temporary 'L)
-     #:with e-rst (generate-temporary #'e)
-     #:with acc (generate-temporary 'acc)
-     #`(let L ([e-rst e][acc null])
-         (syntax-parse e-rst
-           [(pexpander x rst) (L #'rst (cons #'x acc))]
-           [last (reverse (cons #'last acc))]))]))
-
-;; untyped, curried
-(define-syntax (λ/c- stx)
-  (syntax-parse stx
-    [(_ () e) #'e]
-    [(_ (x . rst) e)
-     (syntax/loc stx (λ- (x) (λ/c- rst e)))]))
-
-
-           
-                       
-     
+            [(_ f e . rst)
+             (quasisyntax/loc this-syntax
+               (name #,(syntax/loc this-syntax (name/1 f e)) . rst))])))]))

--- a/turnstile-lib/turnstile/more-utils.rkt
+++ b/turnstile-lib/turnstile/more-utils.rkt
@@ -36,7 +36,7 @@
          (wrap-fn ; eg pattern-expander
           (syntax-parser
             [(_ e) #'e]
-            [(_ x . rst) #'(name/1 x (name . rst))]
+            [(_ x . rst) (syntax/loc this-syntax (name/1 x (name . rst)))]
             )))]))
 (define-syntax define-nested/L
   (syntax-parser

--- a/turnstile-lib/turnstile/turnstile.rkt
+++ b/turnstile-lib/turnstile/turnstile.rkt
@@ -434,7 +434,7 @@
                                             (stx-map
                                              (current-type-eval)
                                              #'#,(stx-append #'b1.expected-ks #'b2.expected-ks)))
-                                  (apply format "k mismatch: ~a has type ~a, expected ~a"
+                                  (apply format "type mismatch: ~a has type ~a, expected ~a"
                                           (for/first
                                               ([ty (in-stx-list τs)]
                                                [k (in-stx-list ks)]
@@ -443,9 +443,9 @@
                                                  (current-type-eval)
                                                  #'#,(stx-append #'b1.expected-ks #'b2.expected-ks))]
                                                #:unless (typecheck? k kexpect))
-                                            (list (stx->datum ty)
-                                                  (stx->datum k)
-                                                  (stx->datum kexpect)))))
+                                            (list ((current-resugar) ty)
+                                                  ((current-resugar) k)
+                                                  ((current-resugar) kexpect)))))
                            (~parse #,(stx-append #'b1.xpats #'b2.xpats) xs+)
                            (~parse #,(stx-append #'b1.τpats #'b2.τpats) τs+)
                            (~parse (tc.e-pat ...) (stx-map (expand1/env ctx) #'(tc.e-stx ...))))))

--- a/turnstile-lib/turnstile/type-constraints.rkt
+++ b/turnstile-lib/turnstile/type-constraints.rkt
@@ -1,0 +1,209 @@
+#lang racket/base
+
+;; this is a copy of type-constraints.rkt from macrotypes-lib,
+;; except it's designed to work with types defined with
+;; turnstile/typedefs library
+
+(provide add-constraints
+         add-constraints/var?
+         lookup
+         lookup-Xs/keep-unsolved
+         inst-type
+         inst-type/orig
+         inst-type/cs
+         inst-types/cs
+         inst-type/cs/orig
+         inst-types/cs/orig
+         datum=?
+         )
+
+(require racket/string
+         racket/match
+         syntax/parse
+         syntax/stx
+         (for-meta -1 macrotypes/typecheck-core)
+         macrotypes/stx-utils
+         )
+
+;; add-constraints :
+;; (Listof Id) (Listof (List Id Type)) (Stx-Listof (Stx-List Stx Stx)) -> (Listof (List Id Type))
+;; Adds a new set of constaints to a substitution, using the type
+;; unification algorithm for local type inference.
+(define (add-constraints Xs substs new-cs [orig-cs new-cs])
+  (define Xs* (stx->list Xs))
+  (define (X? X)
+    (member X Xs* free-identifier=?))
+  (add-constraints/var? Xs* X? substs new-cs orig-cs))
+
+(define (add-constraints/var? Xs* var? substs new-cs [orig-cs new-cs])
+  (define Xs (stx->list Xs*))
+  (define Ys (stx-map stx-car substs))
+  (define-syntax-class var
+    [pattern x:id #:when (var? #'x)])
+  (syntax-parse new-cs
+    [() substs]
+    [([a:var b] . rst)
+     (cond
+       [(member #'a Ys free-identifier=?)
+        ;; There are two cases.
+        ;; Either #'a already maps to #'b or an equivalent type,
+        ;; or #'a already maps to a type that conflicts with #'b.
+        ;; In either case, whatever #'a maps to must be equivalent
+        ;; to #'b, so add that to the constraints.
+        (add-constraints/var?
+         Xs
+         var?
+         substs
+         (cons (list (lookup #'a substs) #'b)
+               #'rst)
+         orig-cs)]
+       [(and (identifier? #'b) (var? #'b) (free-identifier=? #'a #'b))
+        ;; #'a and #'b are equal, drop this constraint
+        (add-constraints/var? Xs var? substs #'rst orig-cs)]
+       [else
+        (define entry (occurs-check (list #'a #'b) orig-cs))
+        (add-constraints/var?
+         Xs
+         var?
+         ;; Add the mapping #'a -> #'b to the substitution,
+         (add-substitution-entry entry substs)
+         ;; and substitute that in each of the constraints.
+         (cs-substitute-entry entry #'rst)
+         orig-cs)])]
+    [([a b:var] . rst)
+     (add-constraints/var? Xs
+                           var?
+                           substs
+                           #'([b a] . rst)
+                           orig-cs)]
+    [([a b] . rst)
+     ;; If #'a and #'b are base types, check that they're equal.
+     ;; Identifers not within Xs count as base types.
+     ;; If #'a and #'b are constructed types, check that the
+     ;; constructors are the same, add the sub-constraints, and
+     ;; recur.
+     ;; Otherwise, raise an error.
+     (cond
+       [(identifier? #'a)
+        ;; #'a is an identifier, but not a var, so it is considered
+        ;; a base type. We also know #'b is not a var, so #'b has
+        ;; to be the same "identifier base type" as #'a.
+        (unless (and (identifier? #'b) (free-identifier=? #'a #'b))
+          (type-error #:src (get-orig #'b)
+                      #:msg (format "couldn't unify ~~a and ~~a\n  expected: ~a\n  given: ~a"
+                                    (string-join (map type->str (stx-map stx-car orig-cs)) ", ")
+                                    (string-join (map type->str (stx-map stx-cadr orig-cs)) ", "))
+                      #'a #'b))
+        (add-constraints/var? Xs
+                              var?
+                              substs
+                              #'rst
+                              orig-cs)]
+       [else
+        (syntax-parse #'[a b]
+          [_
+           #:when (typecheck? #'a #'b)
+           (add-constraints/var? Xs
+                                 var?
+                                 substs
+                                 #'rst
+                                 orig-cs)]
+          [(((~literal #%plain-app) tycons1 τ1 ...) ((~literal #%plain-app) tycons2 τ2 ...))
+           #:when (free-id=? #'tycons1 #'tycons2)
+           #:when (stx-length=? #'[τ1 ...] #'[τ2 ...])
+           (add-constraints/var? Xs
+                                 var?
+                                 substs
+                                 #'((τ1 τ2) ... . rst)
+                                 orig-cs)]
+          [else
+           (type-error #:src (get-orig #'b)
+                       #:msg (format "couldn't unify ~~a and ~~a\n  expected: ~a\n  given: ~a"
+                                     (string-join (map type->str (stx-map stx-car orig-cs)) ", ")
+                                     (string-join (map type->str (stx-map stx-cadr orig-cs)) ", "))
+                       #'a #'b)])])]))
+
+(define (datum=? x y)
+  (equal? (syntax->datum x) (syntax->datum y)))
+
+;; add-substitution-entry : (List Id Type) (Listof (List Id Type)) -> (Listof (List Id Type))
+;; Adds the mapping a -> b to the substitution and substitutes for it in the other entries
+(define (add-substitution-entry entry substs)
+  (match-define (list a b) entry)
+  (cons entry
+        (for/list ([subst (in-list substs)])
+          (list (car subst)
+                (inst-type/orig (list b) (list a) (cadr subst) datum=?)))))
+
+;; cs-substitute-entry : (List Id Type) (Stx-Listof (Stx-List Stx Stx)) -> (Listof (List Stx Stx))
+;; substitute a -> b in each of the constraints
+(define (cs-substitute-entry entry cs)
+  (match-define (list a b) entry)
+  (for/list ([c (in-list (stx->list cs))])
+    (list (inst-type/orig (list b) (list a) (stx-car c) datum=?)
+          (inst-type/orig (list b) (list a) (stx-cadr c) datum=?))))
+
+;; occurs-check : (List Id Type) (Stx-Listof (Stx-List Stx Stx)) -> (List Id Type)
+(define (occurs-check entry orig-cs)
+  (match-define (list a b) entry)
+  (cond [(stx-contains-id? b a)
+         (type-error #:src (get-orig b)
+                     #:msg (format (string-append
+                                    "couldn't unify ~~a and ~~a because one contains the other\n"
+                                    "  expected: ~a\n"
+                                    "  given: ~a")
+                                   (string-join (map type->str (stx-map stx-car orig-cs)) ", ")
+                                   (string-join (map type->str (stx-map stx-cadr orig-cs)) ", "))
+                     a b)]
+        [else entry]))
+
+(define (lookup x substs)
+  (syntax-parse substs
+    [((y:id τ) . rst)
+     #:when (free-identifier=? #'y x)
+     #'τ]
+    [(_ . rst) (lookup x #'rst)]
+    [() #f]))
+
+;; lookup-Xs/keep-unsolved : (Stx-Listof Id) Constraints -> (Listof Type-Stx)
+;; looks up each X in the constraints, returning the X if it's unconstrained
+(define (lookup-Xs/keep-unsolved Xs cs)
+  (for/list ([X (in-stx-list Xs)])
+    (or (lookup X cs) X)))
+
+;; instantiate polymorphic types
+;; inst-type : (Listof Type) (Listof Id) Type -> Type
+;; Instantiates ty with the tys-solved substituted for the Xs, where the ith
+;; identifier in Xs is associated with the ith type in tys-solved
+(define (inst-type tys-solved Xs ty [var=? bound-identifier=?])
+  (substs tys-solved Xs ty var=?))
+;; inst-type/orig : (Listof Type) (Listof Id) Type (Id Id -> Bool) -> Type
+;; like inst-type, but also substitutes within the orig property
+(define (inst-type/orig tys-solved Xs ty [orig-var=? free-identifier=?]
+                                         [inst-var=? bound-identifier=?])
+  (add-orig (inst-type tys-solved Xs ty inst-var=?)
+            (substs (stx-map get-orig tys-solved) Xs (get-orig ty) orig-var=?)))
+
+;; inst-type/cs : (Stx-Listof Id) Constraints Type-Stx -> Type-Stx
+;; Instantiates ty, substituting each identifier in Xs with its mapping in cs.
+(define (inst-type/cs Xs cs ty)
+  (define tys-solved (lookup-Xs/keep-unsolved Xs cs))
+  (inst-type tys-solved Xs ty))
+;; inst-types/cs : (Stx-Listof Id) Constraints (Stx-Listof Type-Stx) -> (Listof Type-Stx)
+;; the plural version of inst-type/cs
+(define (inst-types/cs Xs cs tys)
+  (stx-map (lambda (t) (inst-type/cs Xs cs t)) tys))
+
+;; inst-type/cs/orig :
+;; (Stx-Listof Id) Constraints Type-Stx (Id Id -> Bool) -> Type-Stx
+;; like inst-type/cs, but also substitutes within the orig property
+(define (inst-type/cs/orig Xs cs ty [orig-var=? free-identifier=?]
+                                    [inst-var=? bound-identifier=?])
+  (define tys-solved (lookup-Xs/keep-unsolved Xs cs))
+  (inst-type/orig tys-solved Xs ty orig-var=? inst-var=?))
+;; inst-types/cs/orig :
+;; (Stx-Listof Id) Constraints (Stx-Listof Type-Stx) (Id Id -> Bool) -> (Listof Type-Stx)
+;; the plural version of inst-type/cs/orig
+(define (inst-types/cs/orig Xs cs tys [var=? free-identifier=?])
+  (stx-map (lambda (t) (inst-type/cs/orig Xs cs t var=?)) tys))
+

--- a/turnstile-lib/turnstile/type-constraints.rkt
+++ b/turnstile-lib/turnstile/type-constraints.rkt
@@ -14,7 +14,6 @@
          inst-types/cs
          inst-type/cs/orig
          inst-types/cs/orig
-         datum=?
          )
 
 (require racket/string
@@ -130,9 +129,6 @@
                                      (string-join (map type->str (stx-map stx-car orig-cs)) ", ")
                                      (string-join (map type->str (stx-map stx-cadr orig-cs)) ", "))
                        #'a #'b)])])]))
-
-(define (datum=? x y)
-  (equal? (syntax->datum x) (syntax->datum y)))
 
 ;; add-substitution-entry : (List Id Type) (Listof (List Id Type)) -> (Listof (List Id Type))
 ;; Adds the mapping a -> b to the substitution and substitutes for it in the other entries

--- a/turnstile-lib/turnstile/type-constraints.rkt
+++ b/turnstile-lib/turnstile/type-constraints.rkt
@@ -102,7 +102,7 @@
        [else
         (syntax-parse #'[a b]
           [_
-           #:when (typecheck? #'a #'b)
+           #:when (or (typecheck? #'a #'b) (typecheck? #'b #'a))
            (add-constraints/var? Xs
                                  var?
                                  substs

--- a/turnstile-lib/turnstile/type-constraints.rkt
+++ b/turnstile-lib/turnstile/type-constraints.rkt
@@ -116,6 +116,14 @@
                                  substs
                                  #'((τ1 τ2) ... . rst)
                                  orig-cs)]
+          [(((~literal #%plain-lambda) (x1) e1) ((~literal #%plain-lambda) (x2) e2))
+           #:with x3 (generate-temporary)
+           (add-constraints/var? Xs
+                                 var?
+                                 substs
+                                 #`((#,(subst #'x3 #'x1 #'e1)
+                                     #,(subst #'x3 #'x2 #'e2)) . rst)
+                                 orig-cs)]
           [else
            (type-error #:src (get-orig #'b)
                        #:msg (format "couldn't unify ~~a and ~~a\n  expected: ~a\n  given: ~a"

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -49,7 +49,9 @@
       [((~literal #%plain-app) . rst)
        (datum->syntax this-syntax (stx-map resugar-type #'rst) this-syntax)]
       [((~literal #%plain-lambda) (x:id) body)
-       (quasisyntax/loc this-syntax (λ (x) #,(resugar-type #'body)))]))
+       (quasisyntax/loc this-syntax (λ (x) #,(resugar-type #'body)))]
+      [other
+       (datum->syntax this-syntax (stx-map resugar-type #'other) this-syntax)]))
 
   ;; get-type-info: consumes expanded type with shape (#%plain-app TY:id . rst)
   ;; - returns info useful for pattern matching

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -12,8 +12,9 @@
 
 (define-syntax define-type
   (syntax-parser
+    [(_ (~and x (~not #:extra)) ...) #'(define-type x ... #:extra ())]
     ;; simpler cases
-    [(_ TY:id (~datum :) k) #'(define-type TY : -> k)]
+    [(_ TY:id (~datum :) k #:extra . ei) #'(define-type TY : -> k #:extra . ei)]
     [(_ TY:id
         ;; specifying binders with define-type (ie, a binding type)
         ;; affects the output in 3 (numbered) places (see below)
@@ -32,7 +33,9 @@
                         (~and (~seq k_out ...)
                               (~parse (Y ...) (generate-temporaries #'(k_out ...)))
                               (~parse (Ytag ...) (stx-map (λ _ #':) #'(Y ...)))))
-        (~datum ->) k) ; ⇒ ⇐
+        (~datum ->) k
+        #:extra . extra-info
+        ) ; ⇒ ⇐
      #:with [(Y- ...) (k_out- ...) k-]
             (syntax-parse/typecheck null 
              [_ ≫ ;; TODO: use this X- and Y-?
@@ -83,7 +86,7 @@
                         #'(syntax/loc this-syntax
                             (λ- (X- ...) (#%plain-app list τ_out- ...))))
            ---------------
-           [⊢ (TY/internal τ_in- ... maybe-lambda) ⇒ k]])
+           [⊢ (TY/internal τ_in- ... maybe-lambda) (⇒ : k) (⇒ extra extra-info)]])
          #,@(if (attribute telescope?) (list #'(define-nested/R TY TY/1)) #'())
          (begin-for-syntax
            (define TY/internal+ (expand/df #'TY/internal))

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -69,7 +69,7 @@
       [ty #:when (has-type-info? #'ty) ((get-unexpand-info #'ty) #'ty)]
       [((~and (~literal #%plain-app) app) . rst)
        #:do[(define reflect-name (syntax-property #'app 'display-as))]
-       #:when (stx-e reflect-name)
+       #:when (and reflect-name (stx-e reflect-name))
        (cons reflect-name (stx-map (unexpand/ctx ctx) #'rst))]
       [((~literal #%plain-app) . rst)
        (stx-map (unexpand/ctx ctx) #'rst)]

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -234,10 +234,6 @@
   (syntax-parser
     [(_ TY/internal TY (~optional (~seq #:tag Xtag) #:defaults ([(Xtag 0) #':])))
      #:with TY-expander (mk-~ #'TY)
-     #:with X (fresh #'X)
-     #:with bod (fresh #'bod)
-     #:with τ_in (fresh #'τ_in)
-     #:with τ_out (fresh #'τ_out)
      #`(begin-
          (struct- TY/internal (X bod) #:transparent #:omit-define-syntaxes)
          (begin-for-syntax

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -101,6 +101,8 @@
        (list #'λ #'(x) (resugar-type #'body))]
       [(other ...) (stx-map resugar-type #'(other ...))]
       [other #'other])) ; datums
+
+  (current-resugar (λ (t) (format "~s" (stx->datum (resugar-type t)))))
   )
 
 (define-syntax define-type

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -72,7 +72,11 @@
        ;; TODO: is the src loc right?
        (stx-map unexpand #'rst)]
       [((~literal #%plain-lambda) (x:id) body)
-       (list #'λ #'(x) (unexpand #'body))]
+       ;; TODO: how to unexpand uninferred, ie annotated, lams?
+       ;; - specifically, can only use (typeof this-syntax) if it does not
+       ;;   have unbound tyvar references
+       ;; - see fold tests, eg fold-length-correct, in cur-tests/Poly-pairs.rkt
+       (list 'λ #'x (unexpand #'body))]
       [(other ...) (stx-map unexpand #'(other ...))]
       [other #'other])) ; datums
   ;; returns list of stx objs

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -23,7 +23,7 @@
   ;; queries whether stx has associated type info
   (define has-type-info?
     (syntax-parser
-      [(_ TY+:id . _) (with-handlers ([exn? (λ _ #f)]) (eval-syntax #'TY+))]
+      [(_ TY+:id . _) (with-handlers ([exn? (λ _ #f)]) (type-info? (eval-syntax #'TY+)))]
       [_ #f]))
 
   ;; get-type-info: consumes expanded type with shape (#%plain-app TY:id . rst)

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -87,7 +87,7 @@
       [ty #:when (has-type-info? #'ty) ((get-resugar-info #'ty) #'ty)]
       [((~and (~literal #%plain-app) app) . rst)
        #:do[(define reflect-name (syntax-property #'app 'display-as))]
-       #:when (stx-e reflect-name)
+       #:when (and reflect-name (stx-e reflect-name))
        ;; this must be list not stx obj, ow ctx (for #%app) will be wrong
        ;; in other words, *caller* must create stx obj
        ;; TODO: is the src loc right?

--- a/turnstile-test/info.rkt
+++ b/turnstile-test/info.rkt
@@ -4,10 +4,10 @@
 
 (define deps
   '(("base" #:version "7.0")
-    ("turnstile-example" #:version "0.4.2")
+    ("turnstile-example" #:version "0.4.3")
     ("rackunit-macrotypes-lib" #:version "0.3.1")))
 
 (define pkg-desc "Test suite for \"turnstile\".")
 (define pkg-authors '(stchang))
 
-(define version "0.4.2")
+(define version "0.4.3")

--- a/turnstile-test/info.rkt
+++ b/turnstile-test/info.rkt
@@ -4,10 +4,10 @@
 
 (define deps
   '(("base" #:version "7.0")
-    ("turnstile-example" #:version "0.3.6")
+    ("turnstile-example" #:version "0.4.2")
     ("rackunit-macrotypes-lib" #:version "0.3.1")))
 
 (define pkg-desc "Test suite for \"turnstile\".")
 (define pkg-authors '(stchang))
 
-(define version "0.3.6")
+(define version "0.4.2")

--- a/turnstile-test/tests/turnstile/dep/dep-ind-cur2-bool-tests.rkt
+++ b/turnstile-test/tests/turnstile/dep/dep-ind-cur2-bool-tests.rkt
@@ -13,10 +13,10 @@
 
 (check-type (or_introL True False I) : (Or True False))
 (check-type (or_introL True True I) : (Or True True))
-(typecheck-fail (or_introL False True I) #:with-msg "expected.*X.*given.*True")
+(typecheck-fail (or_introL False True I) #:with-msg "expected.*False.*given.*True")
 (check-type (or_introR False True I) : (Or False True))
 (check-type (or_introR True True I) : (Or True True))
-(typecheck-fail (or_introR True False I) #:with-msg "expected.*Y.*given.*True")
+(typecheck-fail (or_introR True False I) #:with-msg "expected.*False.*given.*True")
 
 (check-type (tauto True) : True)
 (check-type (tauto (And True True)) : (And True True))

--- a/turnstile-test/tests/turnstile/dep/dep-ind-cur2-eq-tests.rkt
+++ b/turnstile-test/tests/turnstile/dep/dep-ind-cur2-eq-tests.rkt
@@ -31,6 +31,7 @@
 (check-type (my-refl Nat Z) : (my= Nat Z Z)) ; 0=0
 (check-not-type (my-refl Nat (S Z)) : (my= Nat Z Z)) ; 1 \neq 0
 (check-type (my-refl Nat (S Z)) : (my= Nat (S Z) (S Z))) ; 1=1
+(check-type (plus (S Z) Z) : Nat -> (S Z))
 (check-type (my-refl Nat (S Z)) : (my= Nat (S Z) (plus (S Z) Z))) ; 1=1+0
 (check-type (my-refl Nat (S Z)) : (my= Nat (plus (S Z) Z) (plus (S Z) Z))) ; 1+0=1+0
 (check-type (my-refl Nat (S Z)) : (my= Nat (plus Z (S Z)) (plus (S Z) Z))) ; 1+0=0+1

--- a/turnstile-test/tests/turnstile/dep/dep-ind-cur2-nat-tests.rkt
+++ b/turnstile-test/tests/turnstile/dep/dep-ind-cur2-nat-tests.rkt
@@ -18,7 +18,7 @@
 (check-type (Type 3) : (Type 4) -> (Type 3))
 
 (typecheck-fail ((λ [x : Type] x) Type)
-  #:with-msg "expected Type, given \\(Type 1\\)")
+  #:with-msg "expected \\(Type 0\\), given \\(Type 1\\)")
 (check-type ((λ [x : (Type 1)] x) Type) : (Type 1))
 (check-type ((λ [x : (Type 2)] x) (Type 1)) : (Type 2))
 

--- a/turnstile-test/tests/turnstile/dep/dep-ind-cur2-tests.rkt
+++ b/turnstile-test/tests/turnstile/dep/dep-ind-cur2-tests.rkt
@@ -30,7 +30,7 @@
 (check-type (Type 3) : (Type 4) -> (Type 3))
 
 (typecheck-fail ((λ [x : Type] x) Type)
-  #:with-msg "expected Type, given \\(Type 1\\)")
+  #:with-msg "expected \\(Type 0\\), given \\(Type 1\\)")
 (check-type ((λ [x : (Type 1)] x) Type) : (Type 1))
 (check-type ((λ [x : (Type 2)] x) (Type 1)) : (Type 2))
 


### PR DESCRIPTION
Exposes define-internal-base-type/new, define-internal-type/new, and
define-internal-binding-type/new.
They still need work, but they're better than nothing.
These are necessary to get complex base typing rules right (like universes and
Π), but still get automatic resugaring support.