### PR TITLE
Wip typedefs

### DIFF
--- a/turnstile-lib/turnstile/type-constraints.rkt
+++ b/turnstile-lib/turnstile/type-constraints.rkt
@@ -22,6 +22,7 @@
          syntax/stx
          (for-meta -1 macrotypes/typecheck-core)
          macrotypes/stx-utils
+         (only-in (for-meta -1 "typedefs.rkt") ~Any/new)
          )
 
 ;; add-constraints :
@@ -107,7 +108,7 @@
                                  substs
                                  #'rst
                                  orig-cs)]
-          [(((~literal #%plain-app) tycons1 τ1 ...) ((~literal #%plain-app) tycons2 τ2 ...))
+          [((~Any/new tycons1 τ1 ...) (~Any/new tycons2 τ2 ...))
            #:when (free-id=? #'tycons1 #'tycons2)
            #:when (stx-length=? #'[τ1 ...] #'[τ2 ...])
            (add-constraints/var? Xs

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -216,6 +216,11 @@
              #:with meths/un #'()))
   )
 
+(define-for-syntax ((make-type-recognizer internal-name) ty)
+  (syntax-parse ty
+    [(~Any/new τcons . rst)
+     (free-identifier=? #'τcons internal-name)]))
+
 (define-syntax define-internal-type/new
   (syntax-parser
     [(_ TY/internal (TY Y ...)
@@ -225,6 +230,7 @@
         (~optional (~seq #:arg-pattern (pat ...)))
         )
      #:with TY-expander (mk-~ #'TY)
+     #:with TY? (mk-? #'TY)
      #:with (arg-pat ...) (or (attribute pat) #'(Y ...))
      ;; TODO - don't know if this lazy pattern needs to be different when there's a rest list
      #:with (maybe-lazy-pattern ...)
@@ -238,6 +244,7 @@
          (struct- TY/internal (Y ... #,@(if (attribute rest?) #'(rst) #'())) #:transparent #:omit-define-syntaxes)
          (begin-for-syntax
            (define TY/internal+ (expand/df #'TY/internal))
+           (define TY? (make-type-recognizer TY/internal+))
            (define-syntax TY-expander
              (pattern-expander
               (syntax-parser

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -225,10 +225,7 @@
                             (~and name/internal:id
                                   (~fail
                                    #:unless (free-id=? #'name/internal
-                                                       TY/internal+)
-                                   (format "Expected ~a type, got: ~a" 'TY
-                                           (stx->datum (resugar-type
-                                                        #'ty-to-match)))))
+                                                       TY/internal+)))
                             arg-pat ...)
                            #'ty-to-match))
                     )])))
@@ -272,10 +269,7 @@
                             (~and name/internal:id
                                   (~fail
                                    #:unless (free-id=? #'name/internal
-                                                       TY/internal+)
-                                   (format "Expected ~a type, got: ~a" 'TY
-                                           (stx->datum (resugar-type
-                                                        #'ty-to-match)))))
+                                                       TY/internal+)))
                             arg-pat ... ((~literal #%plain-app) (~literal list) . rst)
                             #;(~and rest-tys
                                               (~parse rst
@@ -490,10 +484,7 @@
                            (~and name/internal:id
                                  (~fail
                                   #:unless (free-id=? #'name/internal
-                                                      TY/internal+)
-                                  (format "Expected ~a type, got: ~a" 'TY
-                                          (stx->datum (resugar-type
-                                                       #'ty-to-match)))))
+                                                      TY/internal+)))
                            τ_in
                            ((~literal #%plain-lambda) (X) τ_out))
                           #'ty-to-match))])))

--- a/turnstile-lib/turnstile/typedefs.rkt
+++ b/turnstile-lib/turnstile/typedefs.rkt
@@ -270,10 +270,7 @@
                                   (~fail
                                    #:unless (free-id=? #'name/internal
                                                        TY/internal+)))
-                            arg-pat ... ((~literal #%plain-app) (~literal list) . rst)
-                            #;(~and rest-tys
-                                              (~parse rst
-                                                      #'rest-tys)))
+                            arg-pat ... ((~literal #%plain-app) (~literal list) . rst))
                            #'ty-to-match))
                     )])))
            (define TY/internal
@@ -297,9 +294,6 @@
          (struct- TY/internal () #:transparent #:omit-define-syntaxes)
          (begin-for-syntax
            (define TY/internal+ (expand/df #'TY/internal))
-           #;(begin #;begin-for-syntax (local-require racket/pretty)
-                             (printf "TY/internal+\n")
-                             (pretty-print (syntax-debug-info (values #;syntax-local-introduce TY/internal+))))
            (define-syntax TY-expander
              (pattern-expander
               (syntax-parser
@@ -308,17 +302,7 @@
                          (~parse
                           ((~literal #%plain-app) name/internal:id)
                           #'ty-to-match)
-                         (~fail #:unless (or (free-id=? (syntax-local-introduce #'name/internal) #;#'TY/internal TY/internal+)
-                                             #;(let ()
-                                               (printf "BOOHOO\n")
-                                               (printf "found:\n")
-                                               (pretty-print (syntax-debug-info (values #;syntax-local-introduce #'name/internal)))
-                                               (pretty-print (identifier-binding #'name/internal))
-                                               (printf "expected:\n")
-                                               (pretty-print (syntax-debug-info (values #;syntax-local-introduce TY/internal+)))
-                                               (pretty-print (identifier-binding TY/internal+))
-
-                                               #f))))]
+                         (~fail #:unless (free-id=? (syntax-local-introduce #'name/internal) TY/internal+)))]
                 [(_ other-pat (... ...))
                  #'((~and ty-to-match
                           (~parse


### PR DESCRIPTION
these are the changes I've been working on. They include:
- allow `define-type` to create variable-arity type constructors using a trailing `*` in the signature, e.g. `(define-type → : Type Type * -> Type)`
- a version of the `~Any` pattern expander, called `~Any/new` that recognizes typedefs types, including var-arity ones
- bug fixes related to preserving syntax properties and `syntax-local-introduce`-ing in the right spots
- removed uses of `resugar-type` in error messages that can result in a performance pathology
- allow the `get-resugar-info` and `get-unexpand-info` methods to be overridden

things **not** included but possibly worthwhile:
- a version of `define-type-constructor` from Turnstile-. I have one in typed syndicate (probably doesn't include all features) that should maybe be added
- allow for binding types to be var-arity.
- a version of the `~Any/bvs` pattern expander
- allowing for tags other than `:` (I did 90% of this but the last part is fiddly, I can make a separate branch for looking at that if desired)