### PR TITLE
Basic Typed Match

### DIFF
--- a/turnstile-example/turnstile/examples/cs478/current/stlc-prog.rkt
+++ b/turnstile-example/turnstile/examples/cs478/current/stlc-prog.rkt
@@ -73,4 +73,6 @@
 ;; (check-type (ascribe 5 as Int) : Int)
 (check-type (inl 5 as (Sum Int Bool)) : (Sum Int Bool))
 (check-type (inr 6 as (Sum Bool Int)) : (Sum Bool Int))
-;; (check-type (case (inl 3 as (Sum Int Bool)) [(inl x) 1] [(inr y) 2]) : Int -> 1)
+(check-type (case (inl 3 as (Sum Int Bool)) [(inl x) 1] [(inr y) 2]) : Int -> 1)
+
+(typecheck-fail (inl 6 as (Sum Bool Bool)) #:with-msg "sad")

--- a/turnstile-example/turnstile/examples/cs478/current/stlc-prog.rkt
+++ b/turnstile-example/turnstile/examples/cs478/current/stlc-prog.rkt
@@ -96,10 +96,12 @@
             : Int
             -> 9)
 
-(check-type (typed-match [x 5] x) : Int)
-(check-type (typed-match [hello (tup 101 #t)] hello) : (× Int Bool))
-(check-type (typed-match [hello (tup 101 #t)] (proj hello 1)) : Bool)
-(check-type (typed-match [(a b c) (tup 101 #f #t)] a) : Int)
-(check-type (typed-match [(thing) (rec [thing = 5] [other = #f])] thing) : Int)
+(check-type (typed-match ([x 5] [y (tup 101 #t)]) (proj y 0)) : Int -> 101)
+(check-type (typed-match ([(a b c) (tup 101 #f #t)]) a) : Int -> 101)
+(check-type (typed-match ([(a b c d) (tup 101 #f #t 6)]) d) : Int -> 6)
+(check-type (typed-match ([([other = (a b)]) (rec [other = (tup #t 2)] [thing = 5] [g = #f])]) b) : Int -> 2)
 
-;; (typecheck-fail (typed-match [(a b c) (tup 2 3)] c) #:with-msg "sad")
+(check-type (typed-match ([([other = a] [thing = b]) (rec [other = #f] [thing = 2])] [(c d) (tup 8 9)]) (if a b c)) : Int -> 8)
+
+(typecheck-fail (typed-match ([(a b c) (tup 2 3)]) c) #:with-msg "3 pattern variables does not match 2 values in typle")
+(typecheck-fail (typed-match ([([g = hello]) (rec [a = 6])]) hello) #:with-msg "non-existent label g")

--- a/turnstile-example/turnstile/examples/cs478/current/stlc-prog.rkt
+++ b/turnstile-example/turnstile/examples/cs478/current/stlc-prog.rkt
@@ -68,3 +68,9 @@
 (check-type (proj (rec [x = 1] [y = #f]) x) : Int -> 1)
 (check-type (proj (rec [x = 1] [y = #f]) y) : Bool -> #f)
 
+(check-type (vals (rec [x = 1] [y = #f])) : (× Int Bool))
+
+;; (check-type (ascribe 5 as Int) : Int)
+(check-type (inl 5 as (Sum Int Bool)) : (Sum Int Bool))
+(check-type (inr 6 as (Sum Bool Int)) : (Sum Bool Int))
+;; (check-type (case (inl 3 as (Sum Int Bool)) [(inl x) 1] [(inr y) 2]) : Int -> 1)

--- a/turnstile-example/turnstile/examples/cs478/current/stlc-prog.rkt
+++ b/turnstile-example/turnstile/examples/cs478/current/stlc-prog.rkt
@@ -95,3 +95,11 @@
               [inr y => (if y 8 9)])
             : Int
             -> 9)
+
+(check-type (typed-match [x 5] x) : Int)
+(check-type (typed-match [hello (tup 101 #t)] hello) : (× Int Bool))
+(check-type (typed-match [hello (tup 101 #t)] (proj hello 1)) : Bool)
+(check-type (typed-match [(a b c) (tup 101 #f #t)] a) : Int)
+(check-type (typed-match [(thing) (rec [thing = 5] [other = #f])] thing) : Int)
+
+;; (typecheck-fail (typed-match [(a b c) (tup 2 3)] c) #:with-msg "sad")

--- a/turnstile-example/turnstile/examples/cs478/current/stlc.rkt
+++ b/turnstile-example/turnstile/examples/cs478/current/stlc.rkt
@@ -412,21 +412,22 @@
         [(~Sum _ τ-right) (type=? τ #'τ-right)]))))
 
 (define-typerule (inl e (~datum as) τ:type) ≫
-  [⊢ e ≫ e- ⇒ τ1]
-  #:fail-unless (is-left #'τ1 #'τ)  "uh oh sad"
+  [⊢ e ≫ e- ⇒ τ-left]
+  #:fail-unless (is-left #'τ-left #'τ) (format "type ~a isn't left type of Sum ~a" (syntax->datum (stx-e #'τ-left)) (syntax->datum (stx-e #'τ)))
   -------------------------
-  [⊢ (#%app- in-left e-) ⇒ τ])
+  [⊢ (in-left e-) ⇒ τ])
 
 (define-typerule (inr e (~datum as) τ:type) ≫
   [⊢ e ≫ e- ⇒ τ-right]
-  #:fail-unless (is-right #'τ-right #'τ) "uh oh really sad"
+  #:fail-unless (is-right #'τ-right #'τ) (format "type ~a isn't right type of Sum ~a" (stx-e #'τ-right) (stx-e #'τ))
   -------------------------
-  [⊢ (#%app- in-right e-) ⇒ τ])
+  [⊢ (in-right e-) ⇒ τ])
 
+(require (rename-in racket/match [match match-]))
 (define-typerule (case e [((~datum inl) x:id) t1] [((~datum inr) y:id) t2]) ≫
   [⊢ e ≫ e- ⇒ (~Sum τ1 τ2)]
-  [⊢ t1 ≫ t1- ⇒ in-τ1]
-  [⊢ t2 ≫ t2- ⇒ in-τ2]
+  [[x ≫ x- : τ1] ⊢ t1 ≫ t1- ⇒ in-τ1]
+  [[y ≫ y- : τ2] ⊢ t2 ≫ t2- ⇒ in-τ2]
   [in-τ1 τ= in-τ2]
   --------------------------
-  [⊢ (#%app- match- e- [(#%app- in-left x-) t1-] [(#%app- in-right y-) t2-]) ⇒ in-τ1])
+  [⊢ (match- e- [(in-left x-) t1-] [(in-right y-) t2-]) ⇒ in-τ1])

--- a/turnstile-example/turnstile/examples/cs478/current/stlc.rkt
+++ b/turnstile-example/turnstile/examples/cs478/current/stlc.rkt
@@ -398,28 +398,13 @@
 
 (provide inl inr case Sum in-left in-right)
 
-(begin-for-syntax
-  (define (is-left tst-type sum-type)
-    (let ([τ ((current-type-eval) tst-type)]
-          [sum-τ ((current-type-eval) sum-type)])
-      (syntax-parse sum-τ
-        [(~Sum τ-left _) (type=? τ #'τ-left)])))
-
-  (define (is-right tst-type sum-type)
-    (let ([τ ((current-type-eval) tst-type)]
-          [sum-τ ((current-type-eval) sum-type)])
-      (syntax-parse sum-τ
-        [(~Sum _ τ-right) (type=? τ #'τ-right)]))))
-
-(define-typerule (inl e (~datum as) τ:type) ≫
-  [⊢ e ≫ e- ⇒ τ-left]
-  #:fail-unless (is-left #'τ-left #'τ) (format "type ~a isn't left type of Sum ~a" (syntax->datum (stx-e #'τ-left)) (syntax->datum (stx-e #'τ)))
+(define-typerule (inl e (~datum as) (~and τ:type (~parse (~Sum τl _) #'τ.norm))) ≫
+  [⊢ e ≫ e- ⇐ τl]
   -------------------------
   [⊢ (in-left e-) ⇒ τ])
 
-(define-typerule (inr e (~datum as) τ:type) ≫
-  [⊢ e ≫ e- ⇒ τ-right]
-  #:fail-unless (is-right #'τ-right #'τ) (format "type ~a isn't right type of Sum ~a" (stx-e #'τ-right) (stx-e #'τ))
+(define-typerule (inr e (~datum as) (~and τ:type (~parse (~Sum _ τr) #'τ.norm))) ≫
+  [⊢ e ≫ e- ⇐ τr]
   -------------------------
   [⊢ (in-right e-) ⇒ τ])
 

--- a/turnstile-example/turnstile/examples/cs478/current/stlc.rkt
+++ b/turnstile-example/turnstile/examples/cs478/current/stlc.rkt
@@ -327,7 +327,6 @@
      (syntax-parser
        ;; just match on Rec type (assumes ellipses in patter)
        [(_ [name:id (~datum =) τ] (~literal ...))
-        ;; #'(Rec-internal (name τ) (... ...))]
         #'((~literal #%plain-app)
            (~literal Rec-internal)
            ((~literal #%plain-app) ((~literal quote) name) τ) (... ...))]

--- a/turnstile-example/turnstile/examples/cs478/current/stlc.rkt
+++ b/turnstile-example/turnstile/examples/cs478/current/stlc.rkt
@@ -446,3 +446,23 @@
   #;  [⊢ (if- (inl-? e-)
           (let- ([x- (inl--val e-)]) e1-)
           (let- ([y- (inr--val e-)]) e2-)) ⇒ τ])
+
+(provide typed-match)
+(define-typerule typed-match
+  [(_ (x:id e) b) ≫
+   [⊢ e ≫ e- ⇒ τ]
+   [[x ≫ x- : τ] ⊢ b ≫ b- ⇒ τ-out]
+   ---------------------------------
+   [⊢ (let- ([x- e-]) b-) ⇒ τ-out]]
+  [(_ ([x:id ...] e) b) ≫
+   [⊢ e ≫ e- ⇒ (~× τ-tup ...)]
+   #:fail-unless (= (stx-length #'(x ...)) (stx-length #'(τ-tup ...)))
+   (format "~a pattern variables does not match ~a values in tuple" (stx-length #'(x ...)) (stx-length #'(τ-tup ...)))
+   [[x ≫ x- : τ-tup] ... ⊢ b ≫ b- ⇒ τ-out]
+   -----------------------------------------
+   [⊢ (match- e- [(list- x- ...) b-]) ⇒ τ-out]]
+  [(_ ([x:id ...] e) b) ≫
+   [⊢ e ≫ e- ⇒ (~and τ-rec:type (~parse (~Rec [l = τ-label] ...) #'τ-rec.norm))]
+   [[x ≫ x- : ($lookup x [l τ-label] ...)] ... ⊢ b ≫ b- ⇒ τ-out]
+   -----------------------------------------------------------------
+   [⊢ (let- ([x- (cadr- (assoc- x- e-))] ...) b-) ⇒ τ-out]])


### PR DESCRIPTION
Added a `match` esque expression which is more like `match-let` (which is more akin to how it's presented in the book). It can:
- initialize an identifier to any expression
- destructure a tuple
- extract the values at specified labels of a rec

Some follow-ups include adding `_` as a special pattern and more error checking (e.g. no repeat labels in pattern position).

Also added `vals` back in.

Left comments about what I struggled with.